### PR TITLE
Centralize rarity gradients

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,7 +314,8 @@
         </div>
     </div>
 
-    <script>
+    <script type="module">
+        import { rarityGradients } from './scripts/constants.js';
         // Verificar se electronAPI está disponível
         if (!window.electronAPI) {
             console.error('Erro: window.electronAPI não está disponível. Verifique o preload.js');
@@ -354,15 +355,6 @@
             });
         }
 
-        // Objeto de gradientes baseado na raridade
-        const rarityGradients = {
-            'Comum': 'linear-gradient(135deg, #808080, #A9A9A9)',
-            'Incomum': 'linear-gradient(135deg, #D3D3D3, #E0E0E0)',
-            'Raro': 'linear-gradient(135deg, #32CD32, #228B22)',
-            'MuitoRaro': 'linear-gradient(135deg, #4682B4, #1E90FF)',
-            'Epico': 'linear-gradient(135deg, #800080, #DA70D6)',
-            'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
-        };
 
         // Função para carregar os dados do pet e ajustar os alertas
         function loadPet(data) {

--- a/load-pet.html
+++ b/load-pet.html
@@ -161,7 +161,8 @@
         </div>
     </div>
 
-    <script>
+    <script type="module">
+        import { rarityGradients } from './scripts/constants.js';
         // Função para formatar a data
         function formatDate(isoString) {
             const date = new Date(isoString);
@@ -184,15 +185,6 @@
                 .replace(/\b\w/g, c => c.toUpperCase()); // Capitaliza a primeira letra de cada palavra
         }
 
-        // Objeto de gradientes baseado na raridade (copiado do status.js)
-        const rarityGradients = {
-            'Comum': 'linear-gradient(135deg, #808080, #A9A9A9)',
-            'Incomum': 'linear-gradient(135deg, #D3D3D3, #E0E0E0)',
-            'Raro': 'linear-gradient(135deg, #32CD32, #228B22)',
-            'MuitoRaro': 'linear-gradient(135deg, #4682B4, #1E90FF)',
-            'Epico': 'linear-gradient(135deg, #800080, #DA70D6)',
-            'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
-        };
 
         // Função para recarregar a lista de pets
         function reloadPetList() {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -1,0 +1,8 @@
+export const rarityGradients = {
+    'Comum': 'linear-gradient(135deg, #808080, #A9A9A9)',
+    'Incomum': 'linear-gradient(135deg, #D3D3D3, #E0E0E0)',
+    'Raro': 'linear-gradient(135deg, #32CD32, #228B22)',
+    'MuitoRaro': 'linear-gradient(135deg, #4682B4, #1E90FF)',
+    'Epico': 'linear-gradient(135deg, #800080, #DA70D6)',
+    'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
+};

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,3 +1,4 @@
+import { rarityGradients } from './constants.js';
 console.log('status.js carregado com sucesso');
 
 let pet = {};
@@ -130,14 +131,6 @@ function updateStatus() {
     statusEnergyFill.style.width = `${pet.energy || 0}%`;
 
     // Aplicar gradiente com base na raridade apenas na área da imagem do pet
-    const rarityGradients = {
-        'Comum': 'linear-gradient(135deg, #808080, #A9A9A9)',
-        'Incomum': 'linear-gradient(135deg, #D3D3D3, #E0E0E0)',
-        'Raro': 'linear-gradient(135deg, #32CD32, #228B22)',
-        'MuitoRaro': 'linear-gradient(135deg, #4682B4, #1E90FF)',
-        'Epico': 'linear-gradient(135deg, #800080, #DA70D6)',
-        'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
-    };
     const gradient = rarityGradients[pet.rarity] || 'linear-gradient(135deg, #808080, #A9A9A9)';
     console.log('Aplicando gradiente:', gradient);
     statusPetImageGradient.style.background = gradient;

--- a/status.html
+++ b/status.html
@@ -407,7 +407,7 @@
         </div>
     </div>
 
-    <script src="scripts/status.js"></script>
+    <script type="module" src="scripts/status.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- share rarity gradient definitions in `scripts/constants.js`
- load the gradients module in HTML pages and status.js
- remove duplicated gradient objects

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ecdec9d5c832ab7f121787fd08b1f