### PR TITLE
Refactor pet logic into separate modules

### DIFF
--- a/scripts/petExperience.js
+++ b/scripts/petExperience.js
@@ -1,0 +1,43 @@
+const rarityMultipliers = {
+    'Comum': 1.0,
+    'Incomum': 1.05,
+    'Raro': 1.1,
+    'MuitoRaro': 1.2,
+    'Epico': 1.35,
+    'Lendario': 1.55
+};
+
+function getRequiredXpForNextLevel(level) {
+    const baseXp = 100;
+    const scale = 1.2;
+    return Math.round(baseXp * Math.pow(level, 1.5) * scale);
+}
+
+function calculateXpGain(baseXp, rarity) {
+    const multiplier = rarityMultipliers[rarity] || 1.0;
+    return Math.round(baseXp * multiplier);
+}
+
+function increaseAttributesOnLevelUp(pet) {
+    const attributes = pet.attributes;
+    const oldLife = attributes.life;
+    const oldHealthPercentage = pet.currentHealth / pet.maxHealth;
+
+    attributes.life = (attributes.life || 0) + Math.floor(Math.random() * 3) + 1;
+    attributes.attack = (attributes.attack || 0) + Math.floor(Math.random() * 3) + 1;
+    attributes.defense = (attributes.defense || 0) + Math.floor(Math.random() * 3) + 1;
+    attributes.speed = (attributes.speed || 0) + Math.floor(Math.random() * 3) + 1;
+    attributes.magic = (attributes.magic || 0) + Math.floor(Math.random() * 3) + 1;
+
+    pet.maxHealth = attributes.life;
+    pet.currentHealth = Math.round(oldHealthPercentage * pet.maxHealth);
+
+    console.log('Atributos aumentados:', attributes);
+    console.log(`Vida ajustada: ${oldHealthPercentage * 100}% de ${oldLife} -> ${pet.currentHealth} de ${pet.maxHealth}`);
+}
+
+module.exports = {
+    getRequiredXpForNextLevel,
+    calculateXpGain,
+    increaseAttributesOnLevelUp
+};

--- a/scripts/petUpdater.js
+++ b/scripts/petUpdater.js
@@ -1,0 +1,111 @@
+const { BrowserWindow } = require('electron');
+const petManager = require('./petManager');
+
+let lastRecovery = Date.now();
+let lastHungerUpdate = Date.now();
+let lastHappinessUpdate = Date.now();
+
+function resetTimers() {
+    lastRecovery = Date.now();
+    lastHungerUpdate = Date.now();
+    lastHappinessUpdate = Date.now();
+}
+
+function startPetUpdater(getCurrentPet) {
+
+    setInterval(async () => {
+        const currentPet = getCurrentPet();
+        console.log('setInterval rodando, currentPet:', currentPet ? 'definido' : 'null');
+        if (currentPet) {
+            const now = Date.now();
+
+            const elapsedHungerSeconds = Math.floor((now - lastHungerUpdate) / 1000);
+            const elapsedHappinessSeconds = Math.floor((now - lastHappinessUpdate) / 1000);
+            const elapsedRecoverySeconds = Math.floor((now - lastRecovery) / 1000);
+
+            console.log('Tempo decorrido (segundos) - Hunger:', elapsedHungerSeconds, 'Happiness:', elapsedHappinessSeconds);
+            console.log('Valores antes do decaimento:', { hunger: currentPet.hunger, happiness: currentPet.happiness });
+
+            const hungerDecay = Math.floor(elapsedHungerSeconds / 180);
+            const happinessDecay = Math.floor(elapsedHappinessSeconds / 300);
+            console.log('Decaimento calculado:', { hungerDecay, happinessDecay });
+
+            let decayApplied = false;
+
+            if (hungerDecay > 0 || happinessDecay > 0) {
+                const oldHunger = currentPet.hunger;
+                const oldHappiness = currentPet.happiness;
+                currentPet.hunger = Math.max(currentPet.hunger - hungerDecay, 0);
+                currentPet.happiness = Math.max(currentPet.happiness - happinessDecay, 0);
+                console.log(`Decaimento aplicado: Fome ${oldHunger} -> ${currentPet.hunger}, Felicidade ${oldHappiness} -> ${currentPet.happiness}`);
+
+                if (hungerDecay > 0) {
+                    console.log('Fome decaiu! Novo valor:', currentPet.hunger);
+                }
+
+                try {
+                    await petManager.updatePet(currentPet.petId, {
+                        hunger: currentPet.hunger,
+                        happiness: currentPet.happiness,
+                        currentHealth: currentPet.currentHealth,
+                        energy: currentPet.energy,
+                        level: currentPet.level,
+                        experience: currentPet.experience,
+                        attributes: currentPet.attributes,
+                        maxHealth: currentPet.maxHealth
+                    });
+                    console.log('Pet atualizado no banco de dados com sucesso');
+                    decayApplied = true;
+                } catch (err) {
+                    console.error('Erro ao atualizar pet:', err);
+                }
+
+                if (hungerDecay > 0) lastHungerUpdate = now;
+                if (happinessDecay > 0) lastHappinessUpdate = now;
+            } else {
+                console.log('Nenhum decaimento aplicado (hungerDecay e happinessDecay são 0)');
+            }
+
+            if (elapsedRecoverySeconds >= 90 && (currentPet.currentHealth < currentPet.maxHealth || currentPet.energy < 100)) {
+                const oldHealth = currentPet.currentHealth;
+                const oldEnergy = currentPet.energy;
+                currentPet.currentHealth = Math.min(currentPet.currentHealth + 1, currentPet.maxHealth);
+                currentPet.energy = Math.min(currentPet.energy + 1, 100);
+                console.log(`Recuperação aplicada: Vida ${oldHealth} -> ${currentPet.currentHealth}, Energia ${oldEnergy} -> ${currentPet.energy}`);
+
+                try {
+                    await petManager.updatePet(currentPet.petId, {
+                        currentHealth: currentPet.currentHealth,
+                        energy: currentPet.energy,
+                        level: currentPet.level,
+                        experience: currentPet.experience,
+                        attributes: currentPet.attributes,
+                        maxHealth: currentPet.maxHealth
+                    });
+                } catch (err) {
+                    console.error('Erro ao atualizar pet na recuperação:', err);
+                }
+
+                lastRecovery = now;
+
+                BrowserWindow.getAllWindows().forEach(window => {
+                    if (window.webContents) {
+                        window.webContents.send('pet-data', currentPet);
+                    }
+                });
+            }
+
+            if (decayApplied) {
+                BrowserWindow.getAllWindows().forEach(window => {
+                    if (window.webContents) {
+                        window.webContents.send('pet-data', currentPet);
+                    }
+                });
+            }
+        } else {
+            console.log('Nenhum pet selecionado (currentPet é null)');
+        }
+    }, 1000);
+}
+
+module.exports = { startPetUpdater, resetTimers };


### PR DESCRIPTION
## Summary
- extract XP and level functions into `scripts/petExperience.js`
- move periodic pet update logic into `scripts/petUpdater.js`
- initialise updater and use new helpers from `main.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ecdf7dfec832aaa0f6caa0c7fc394