### PR TITLE
Load quiz questions from JSON

### DIFF
--- a/data/questions.json
+++ b/data/questions.json
@@ -1,0 +1,162 @@
+[
+  {
+    "text": "Você está perdido em uma floresta. O que você faz?",
+    "options": [
+      {"text": "Procuro um rio para seguir", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Escalo uma árvore para me orientar", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}},
+      {"text": "Construo um abrigo e espero ajuda", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}}
+    ]
+  },
+  {
+    "text": "Um estranho se aproxima. Qual é sua reação?",
+    "options": [
+      {"text": "Fico em guarda e observo", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 0}},
+      {"text": "Saúdo amigavelmente", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Me escondo rapidamente", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra um artefato brilhante. O que faz?",
+    "options": [
+      {"text": "Toco para ver o que acontece", "points": {"attack": 1, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Estudo de longe", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Ignoro e sigo em frente", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Está escurecendo. Como você se prepara?",
+    "options": [
+      {"text": "Acendo uma fogueira", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Procuro um lugar seguro", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Continuo andando", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você ouve um rugido à distância. O que faz?",
+    "options": [
+      {"text": "Vou investigar", "points": {"attack": 1, "defense": 0, "speed": 0, "magic": 0, "life": 0}},
+      {"text": "Fico quieto e observo", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Corro na direção oposta", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra uma caverna misteriosa. O que faz?",
+    "options": [
+      {"text": "Entro para explorar", "points": {"attack": 1, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Observo de fora", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Passo longe dela", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Está chovendo forte. Qual é sua atitude?",
+    "options": [
+      {"text": "Aproveito para descansar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Procuro abrigo", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Continuo minha jornada", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra um lago cristalino. O que faz?",
+    "options": [
+      {"text": "Mergulho para nadar", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 1}},
+      {"text": "Bebo a água", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Sigo meu caminho", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Um pássaro gigante voa sobre você. O que faz?",
+    "options": [
+      {"text": "Tento chamar sua atenção", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Me escondo", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 0}},
+      {"text": "Observo de longe", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}}
+    ]
+  },
+  {
+    "text": "Você encontra uma planta estranha. O que faz?",
+    "options": [
+      {"text": "Toco para sentir", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Estudo sem tocar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Evito e sigo em frente", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você sente um tremor. O que faz?",
+    "options": [
+      {"text": "Corro para um lugar aberto", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}},
+      {"text": "Procuro algo para me proteger", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Fico parado e observo", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra um caminho bifurcado. Qual escolhe?",
+    "options": [
+      {"text": "O caminho escuro e misterioso", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "O caminho iluminado e tranquilo", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "O caminho estreito e rápido", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você ouve um som estranho. O que faz?",
+    "options": [
+      {"text": "Investigo a origem", "points": {"attack": 1, "defense": 0, "speed": 0, "magic": 0, "life": 0}},
+      {"text": "Fico alerta mas não me movo", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Saio rapidamente", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra uma pedra brilhante. O que faz?",
+    "options": [
+      {"text": "Pego para examinar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Observo sem tocar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Deixo para trás", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Está muito quente. Como você reage?",
+    "options": [
+      {"text": "Procuro sombra", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Continuo andando", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}},
+      {"text": "Tento encontrar água", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}}
+    ]
+  },
+  {
+    "text": "Você encontra um animal ferido. O que faz?",
+    "options": [
+      {"text": "Tento ajudar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Observo de longe", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Sigo meu caminho", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você vê um arco-íris. O que faz?",
+    "options": [
+      {"text": "Tento seguir até o fim", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 1, "life": 0}},
+      {"text": "Aprecio a vista", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Ignoro e sigo em frente", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra uma ponte quebrada. O que faz?",
+    "options": [
+      {"text": "Tento atravessar com cuidado", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}},
+      {"text": "Procuro outro caminho", "points": {"attack": 0, "defense": 1, "speed": 0, "magic": 0, "life": 1}},
+      {"text": "Construo algo para atravessar", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}}
+    ]
+  },
+  {
+    "text": "Você vê uma estrela cadente. O que faz?",
+    "options": [
+      {"text": "Faço um pedido", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Observo em silêncio", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 0}},
+      {"text": "Sigo meu caminho", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  },
+  {
+    "text": "Você encontra um mapa antigo. O que faz?",
+    "options": [
+      {"text": "Sigo o mapa", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}},
+      {"text": "Guardo para estudar depois", "points": {"attack": 0, "defense": 0, "speed": 0, "magic": 1, "life": 1}},
+      {"text": "Ignoro o mapa", "points": {"attack": 0, "defense": 0, "speed": 1, "magic": 0, "life": 0}}
+    ]
+  }
+]

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -11,170 +11,19 @@ const specieImages = {
     'Fera': 'fera/fera.png'
 };
 
-// Lista de 20 perguntas com 3 alternativas cada, e pontuações para os atributos
-const questions = [
-    {
-        text: "Você está perdido em uma floresta. O que você faz?",
-        options: [
-            { text: "Procuro um rio para seguir", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Escalo uma árvore para me orientar", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-            { text: "Construo um abrigo e espero ajuda", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-        ],
-    },
-    {
-        text: "Um estranho se aproxima. Qual é sua reação?",
-        options: [
-            { text: "Fico em guarda e observo", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 0 } },
-            { text: "Saúdo amigavelmente", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Me escondo rapidamente", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra um artefato brilhante. O que faz?",
-        options: [
-            { text: "Toco para ver o que acontece", points: { attack: 1, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Estudo de longe", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Ignoro e sigo em frente", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Está escurecendo. Como você se prepara?",
-        options: [
-            { text: "Acendo uma fogueira", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Procuro um lugar seguro", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Continuo andando", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você ouve um rugido à distância. O que faz?",
-        options: [
-            { text: "Vou investigar", points: { attack: 1, defense: 0, speed: 0, magic: 0, life: 0 } },
-            { text: "Fico quieto e observo", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Corro na direção oposta", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra uma caverna misteriosa. O que faz?",
-        options: [
-            { text: "Entro para explorar", points: { attack: 1, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Observo de fora", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Passo longe dela", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Está chovendo forte. Qual é sua atitude?",
-        options: [
-            { text: "Aproveito para descansar", points: { attack: 0, defense: 0, speed: 0, magic: 0, life: 1 } },
-            { text: "Procuro abrigo", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Continuo minha jornada", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra um lago cristalino. O que faz?",
-        options: [
-            { text: "Mergulho para nadar", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 1 } },
-            { text: "Bebo a água", points: { attack: 0, defense: 0, speed: 0, magic: 0, life: 1 } },
-            { text: "Sigo meu caminho", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Um pássaro gigante voa sobre você. O que faz?",
-        options: [
-            { text: "Tento chamar sua atenção", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Me escondo", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 0 } },
-            { text: "Observo de longe", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-        ],
-    },
-    {
-        text: "Você encontra uma planta estranha. O que faz?",
-        options: [
-            { text: "Toco para sentir", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Estudo sem tocar", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Evito e sigo em frente", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você sente um tremor. O que faz?",
-        options: [
-            { text: "Corro para um lugar aberto", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-            { text: "Procuro algo para me proteger", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Fico parado e observo", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra um caminho bifurcado. Qual escolhe?",
-        options: [
-            { text: "O caminho escuro e misterioso", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "O caminho iluminado e tranquilo", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "O caminho estreito e rápido", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você ouve um som estranho. O que faz?",
-        options: [
-            { text: "Investigo a origem", points: { attack: 1, defense: 0, speed: 0, magic: 0, life: 0 } },
-            { text: "Fico alerta mas não me movo", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Saio rapidamente", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra uma pedra brilhante. O que faz?",
-        options: [
-            { text: "Pego para examinar", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Observo sem tocar", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Deixo para trás", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Está muito quente. Como você reage?",
-        options: [
-            { text: "Procuro sombra", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Continuo andando", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-            { text: "Tento encontrar água", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-        ],
-    },
-    {
-        text: "Você encontra um animal ferido. O que faz?",
-        options: [
-            { text: "Tento ajudar", points: { attack: 0, defense: 0, speed: 0, magic: 0, life: 1 } },
-            { text: "Observo de longe", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Sigo meu caminho", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você vê um arco-íris. O que faz?",
-        options: [
-            { text: "Tento seguir até o fim", points: { attack: 0, defense: 0, speed: 1, magic: 1, life: 0 } },
-            { text: "Aprecio a vista", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Ignoro e sigo em frente", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra uma ponte quebrada. O que faz?",
-        options: [
-            { text: "Tento atravessar com cuidado", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-            { text: "Procuro outro caminho", points: { attack: 0, defense: 1, speed: 0, magic: 0, life: 1 } },
-            { text: "Construo algo para atravessar", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-        ],
-    },
-    {
-        text: "Você vê uma estrela cadente. O que faz?",
-        options: [
-            { text: "Faço um pedido", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Observo em silêncio", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 0 } },
-            { text: "Sigo meu caminho", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-    {
-        text: "Você encontra um mapa antigo. O que faz?",
-        options: [
-            { text: "Sigo o mapa", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-            { text: "Guardo para estudar depois", points: { attack: 0, defense: 0, speed: 0, magic: 1, life: 1 } },
-            { text: "Ignoro o mapa", points: { attack: 0, defense: 0, speed: 1, magic: 0, life: 0 } },
-        ],
-    },
-];
+// Perguntas carregadas de data/questions.json
 
+let questions = [];
+
+function loadQuestions() {
+    return fetch('data/questions.json')
+        .then(response => response.json())
+        .then(data => {
+            questions = data;
+            initQuiz();
+        })
+        .catch(error => console.error('Erro ao carregar as perguntas:', error));
+}
 // Função para gerar a raridade
 function generateRarity() {
     const roll = Math.floor(Math.random() * 100);
@@ -405,6 +254,9 @@ function showNameSelection(element) {
     }, { once: true }); // Listener único
 }
 
-// Inicializar o quiz
-selectedQuestions.push(...selectRandomQuestions());
-showQuestion();
+function initQuiz() {
+    selectedQuestions.push(...selectRandomQuestions());
+    showQuestion();
+}
+
+document.addEventListener('DOMContentLoaded', loadQuestions);


### PR DESCRIPTION
## Summary
- move quiz questions to `data/questions.json`
- load questions at runtime in `create-pet.js` and start quiz after fetch

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ece3822b4832a831e4dcee888901d