### PR TITLE
Add back button and auto sizing to journey window

### DIFF
--- a/journey-mode.html
+++ b/journey-mode.html
@@ -9,18 +9,21 @@
     <style>
         html { width: 100%; height: 100%; }
         body { background: transparent; margin: 0; padding: 0; }
-        .window { position: relative; width: 100%; height: 100%; display: flex; flex-direction: column; margin: 0; padding: 0; }
+        .window { position: relative; display: flex; flex-direction: column; margin: 0; padding: 0; width: fit-content; height: fit-content; }
         #title-bar { width: 100%; height: 30px; background-color: #3a4450; -webkit-app-region: drag; display: flex; align-items: center; justify-content: space-between; padding: 0 5px; }
         #title-bar-content { display: flex; align-items: center; flex-grow: 1; }
         #close-journey-mode { width: 20px; height: 20px; background-color: #ff4444; border-radius: 50%; cursor: pointer; -webkit-app-region: no-drag; display: flex; align-items: center; justify-content: center; color: #813a3a; font-family: cursive; font-size: 12px; font-weight: bold; text-shadow: none; }
-        #journey-container { flex: 1; padding: 10px; margin: 5px; display: flex; flex-direction: column; }
+        #title-bar-buttons { display: flex; gap: 5px; -webkit-app-region: no-drag; }
+        #back-journey-mode { width: 20px; height: 20px; background-color: #44aaff; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; color: #2a435b; font-family: cursive; font-size: 12px; font-weight: bold; text-shadow: none; }
+        #journey-container { padding: 10px; margin: 5px; display: flex; flex-direction: column; width: fit-content; height: fit-content; }
 
         #missions-grid {
-            flex: 1;
             display: grid;
             grid-template-columns: repeat(4, 1fr);
             grid-auto-rows: 1.2fr;
             gap: 10px;
+            width: fit-content;
+            height: fit-content;
         }
         .mission-tile {
             position: relative;
@@ -31,7 +34,8 @@
             display: flex;
             align-items: flex-end;
             justify-content: center;
-            min-height: 120px;
+            min-height: 130px;
+            min-width: 200px;
         }
         .mission-info { background-color: rgba(0,0,0,0.5); width: 100%; text-align: center; color: #ffffff; font-family: 'PixelOperator', sans-serif; padding: 2px 0; }
         .lock-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.6); display: none; align-items: center; justify-content: center; font-size: 32px; }
@@ -42,7 +46,10 @@
     <div class="window">
         <div id="title-bar">
             <div id="title-bar-content"><span>Modo Jornada</span></div>
-            <div id="close-journey-mode">X</div>
+            <div id="title-bar-buttons">
+                <div id="back-journey-mode">↩</div>
+                <div id="close-journey-mode">X</div>
+            </div>
         </div>
         <div id="journey-container">
             <div id="missions-grid"></div>

--- a/main.js
+++ b/main.js
@@ -360,6 +360,12 @@ ipcMain.on('open-journey-mode-window', () => {
     }
 });
 
+ipcMain.on('resize-journey-window', (event, size) => {
+    if (journeyModeWindow && size && size.width && size.height) {
+        journeyModeWindow.setSize(Math.round(size.width), Math.round(size.height));
+    }
+});
+
 // Novos handlers IPC para o electron-store
 ipcMain.handle('get-mute-state', async () => {
     console.log('Recebido get-mute-state');

--- a/preload.js
+++ b/preload.js
@@ -21,6 +21,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'train-pet',
             'open-battle-mode-window',
             'open-journey-mode-window',
+            'resize-journey-window',
             'set-mute-state',
             'animation-finished' // Novo canal pra sinalizar o fim da animação
         ];

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -9,6 +9,10 @@ function closeWindow() {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('close-journey-mode')?.addEventListener('click', closeWindow);
+    document.getElementById('back-journey-mode')?.addEventListener('click', () => {
+        window.electronAPI.send('open-battle-mode-window');
+        window.close();
+    });
 
     const missions = [
         { name: 'Bosque Sombrio', range: '1~3', minLevel: 1, image: 'Assets/Modes/Journeys/forest.jpg' },
@@ -54,6 +58,12 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     updateLocks();
+
+    const container = document.getElementById('journey-container');
+    const titleBar = document.getElementById('title-bar');
+    const totalWidth = container.scrollWidth + 10; // small padding
+    const totalHeight = titleBar.offsetHeight + container.scrollHeight + 10;
+    window.electronAPI.send('resize-journey-window', { width: totalWidth, height: totalHeight });
 });
 
 function updateLocks() {


### PR DESCRIPTION
## Summary
- resize journey window dynamically based on mission grid
- add back button next to close button on journey mode window
- allow mission tiles to be at least 200x130
- expose resize IPC channel and handle it

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684ed8e592e8832ab169dda788dff079