### PR TITLE
Update moves UI

### DIFF
--- a/scripts/train.js
+++ b/scripts/train.js
@@ -39,15 +39,34 @@ function renderMoves(moves) {
         if (pet.moves && pet.moves.length >= 4 && !known) action = 'Trocar';
         if (pet.level < move.level) action = 'Indisponível';
 
+        const elementIcons = move.elements.map(el =>
+            `<img class="element-icon" src="Assets/Elements/${el}.png" alt="${el}">`
+        ).join(' ');
+
+        let actionClass = '';
+        switch (action) {
+            case 'Aprender':
+                actionClass = 'action-aprender';
+                break;
+            case 'Reaprender':
+                actionClass = 'action-reaprender';
+                break;
+            case 'Trocar':
+                actionClass = 'action-trocar';
+                break;
+            default:
+                actionClass = 'action-indisponivel';
+        }
+
         tr.innerHTML = `
             <td>${move.name}</td>
             <td>${move.rarity}</td>
-            <td>${move.elements.join(', ')}</td>
+            <td>${elementIcons}</td>
             <td>${move.power}</td>
             <td>${move.effect}</td>
             <td>${move.cost}</td>
             <td>${move.level}</td>
-            <td><button class="button action-button">${action}</button></td>
+            <td><button class="button action-button ${actionClass}">${action}</button></td>
         `;
 
         const btn = tr.querySelector('button');

--- a/status.html
+++ b/status.html
@@ -318,8 +318,13 @@
         #status-moves {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
+            grid-template-rows: repeat(2, auto);
             gap: 5px;
             margin-bottom: 5px;
+        }
+
+        .moves-grid {
+            display: contents;
         }
 
         .move-slot {
@@ -427,7 +432,7 @@
                     </div>
                     <div id="tab-moves" class="tab-content-item">
                         <div id="status-moves"></div>
-                        <button class="button" id="train-moves-button">Treinar Golpes</button>
+                        <button class="button small-button" id="train-moves-button">Treinar</button>
                     </div>
                 </div>
             </div>

--- a/styles/main.css
+++ b/styles/main.css
@@ -58,6 +58,12 @@ body {
     text-align: center;
 }
 
+.small-button {
+    width: 80px;
+    font-size: 14px;
+    padding: 4px 8px;
+}
+
 .button:hover {
     background-color: #3a4250; /* Um tom mais claro para hover */
 }

--- a/train.html
+++ b/train.html
@@ -17,6 +17,11 @@
         th, td { border:1px solid #2a323e; padding:4px; text-align:center; font-size:14px; }
         th { background:#2a323e; }
         .action-button:disabled { opacity:0.5; cursor:default; }
+        .element-icon { width:24px; height:24px; }
+        .action-aprender { background-color:#2ecc71; }
+        .action-reaprender { background-color:#3498db; }
+        .action-trocar { background-color:#f1c40f; }
+        .action-indisponivel { background-color:#7f8c8d; }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- show element icons on training screen and color code actions
- support smaller buttons
- display moves in 2x2 grid with a small 'Treinar' button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684edf8d609c832abff971ea581f0fa1