### PR TITLE
Fix close button placement on train window

### DIFF
--- a/train.html
+++ b/train.html
@@ -8,10 +8,44 @@
     <link rel="stylesheet" href="styles/main.css">
     <style>
         html, body { width:100%; height:100%; margin:0; padding:0; background:transparent; }
-        .window { width:100%; height:100%; display:flex; flex-direction:column; }
-        #title-bar { width:100%; height:30px; background:#3a4450; -webkit-app-region:drag; display:flex; align-items:center; justify-content:space-between; padding:0 5px; }
+        .window {
+            position: relative;
+            width: 100%;
+            height: 100%;
+            display: flex;
+            flex-direction: column;
+        }
+        #title-bar {
+            position: relative;
+            width: 100%;
+            height: 30px;
+            background: #3a4450;
+            -webkit-app-region: drag;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 0 5px;
+        }
         #title-bar-content { display:flex; align-items:center; flex-grow:1; }
-        #close-train-window { width:20px; height:20px; background-color:#ff4444; border-radius:50%; cursor:pointer; -webkit-app-region:no-drag; display:flex; align-items:center; justify-content:center; color:#813a3a; font-family:cursive; font-size:12px; font-weight:bold; text-shadow:none; }
+        #close-train-window {
+            position: absolute;
+            top: 5px;
+            right: 5px;
+            width: 20px;
+            height: 20px;
+            background-color: #ff4444;
+            border-radius: 50%;
+            cursor: pointer;
+            -webkit-app-region: no-drag;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #813a3a;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
         #train-container { flex:1; padding:0; overflow-y:auto; }
         table { width:100%; border-collapse:collapse; table-layout:fixed; }
         th, td { border:1px solid #2a323e; padding:4px; text-align:center; font-size:14px; }


### PR DESCRIPTION
## Summary
- keep the training window title bar relative positioned
- absolutely position the close button in the top-right corner of the window

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f090d8708832aa5446f7ea0a74208