### PR TITLE
Dynamic loading for journey missions

### DIFF
--- a/main.js
+++ b/main.js
@@ -3,6 +3,8 @@ const windowManager = require('./scripts/windowManager');
 const petManager = require('./scripts/petManager');
 const { getRequiredXpForNextLevel, calculateXpGain, increaseAttributesOnLevelUp } = require('./scripts/petExperience');
 const { startPetUpdater, resetTimers } = require('./scripts/petUpdater');
+const fs = require('fs');
+const path = require('path');
 
 // Importar o electron-store no processo principal
 let Store;
@@ -432,6 +434,18 @@ ipcMain.on('set-mute-state', (event, isMuted) => {
     console.log('Recebido set-mute-state:', isMuted);
     store.set('isMuted', isMuted);
     console.log('Estado de mute salvo:', isMuted);
+});
+
+ipcMain.handle('get-journey-images', async () => {
+    try {
+        const dir = path.join(__dirname, 'Assets', 'Modes', 'Journeys');
+        const files = await fs.promises.readdir(dir);
+        return files.filter(f => /\.(png|jpg|jpeg|gif)$/i.test(f))
+            .map(f => path.join('Assets', 'Modes', 'Journeys', f));
+    } catch (err) {
+        console.error('Erro ao listar imagens de jornada:', err);
+        return [];
+    }
 });
 
 module.exports = { app, ipcMain, globalShortcut, windowManager, petManager };

--- a/preload.js
+++ b/preload.js
@@ -24,6 +24,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'open-journey-mode-window',
             'resize-journey-window',
             'set-mute-state',
+            'get-journey-images',
             'animation-finished' // Novo canal pra sinalizar o fim da animação
         ];
         if (validChannels.includes(channel)) {
@@ -77,6 +78,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getMuteState: () => {
         console.log('Enviando get-mute-state');
         return ipcRenderer.invoke('get-mute-state');
+    },
+    getJourneyImages: () => {
+        console.log('Enviando get-journey-images');
+        return ipcRenderer.invoke('get-journey-images');
     }
 });
 

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -14,56 +14,43 @@ document.addEventListener('DOMContentLoaded', () => {
         window.close();
     });
 
-    const missions = [
-        { name: 'Bosque Sombrio', range: '1~3', minLevel: 1, image: 'Assets/Modes/Journeys/forest.jpg' },
-        { name: 'Lago Sereno', range: '4~7', minLevel: 4, image: 'Assets/Modes/Journeys/lake.jpg' },
-        { name: 'Montanha Sagrada', range: '8~11', minLevel: 8, image: 'Assets/Modes/Journeys/mountain.jpg' },
-        { name: 'Abismo Profundo', range: '12~15', minLevel: 12, image: 'Assets/Modes/Journeys/abyss.jpg' },
-        { name: 'Bosque Místico', range: '16~19', minLevel: 16, image: 'Assets/Modes/Journeys/forest.jpg' },
-        { name: 'Lago Congelado', range: '20~23', minLevel: 20, image: 'Assets/Modes/Journeys/lake.jpg' },
-        { name: 'Montanha Ardente', range: '24~27', minLevel: 24, image: 'Assets/Modes/Journeys/mountain.jpg' },
-        { name: 'Abismo das Sombras', range: '28~31', minLevel: 28, image: 'Assets/Modes/Journeys/abyss.jpg' },
-        { name: 'Bosque Encantado', range: '32~35', minLevel: 32, image: 'Assets/Modes/Journeys/forest.jpg' },
-        { name: 'Lago Esmeralda', range: '36~39', minLevel: 36, image: 'Assets/Modes/Journeys/lake.jpg' },
-        { name: 'Montanha dos Ventos', range: '40~43', minLevel: 40, image: 'Assets/Modes/Journeys/mountain.jpg' },
-        { name: 'Abismo Eterno', range: '44~47', minLevel: 44, image: 'Assets/Modes/Journeys/abyss.jpg' },
-        { name: 'Bosque dos Anciões', range: '48~51', minLevel: 48, image: 'Assets/Modes/Journeys/forest.jpg' },
-        { name: 'Lago Dourado', range: '52~55', minLevel: 52, image: 'Assets/Modes/Journeys/lake.jpg' },
-        { name: 'Montanha Celeste', range: '56~59', minLevel: 56, image: 'Assets/Modes/Journeys/mountain.jpg' },
-        { name: 'Abismo Infinito', range: '60~63', minLevel: 60, image: 'Assets/Modes/Journeys/abyss.jpg' },
-        { name: 'Bosque Gélido', range: '64~67', minLevel: 64, image: 'Assets/Modes/Journeys/forest.jpg' },
-        { name: 'Lago das Névoas', range: '68~71', minLevel: 68, image: 'Assets/Modes/Journeys/lake.jpg' },
-        { name: 'Montanha Selvagem', range: '72~75', minLevel: 72, image: 'Assets/Modes/Journeys/mountain.jpg' },
-        { name: 'Abismo do Fim', range: '76~79', minLevel: 76, image: 'Assets/Modes/Journeys/abyss.jpg' }
-    ];
+    window.electronAPI.getJourneyImages().then(files => {
+        const missions = files.map((img, idx) => {
+            const base = img.split(/[\\/]/).pop().replace(/\.[^.]+$/, '');
+            const formatted = base.replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            const min = idx * 4 + 1;
+            const range = `${min}~${min + 3}`;
+            return { name: formatted, range, minLevel: min, image: img };
+        });
 
-    const grid = document.getElementById('missions-grid');
-    missions.forEach(mission => {
-        const tile = document.createElement('div');
-        tile.className = 'mission-tile';
-        tile.style.backgroundImage = `url('${mission.image}')`;
-        tile.dataset.minLevel = mission.minLevel;
+        const grid = document.getElementById('missions-grid');
+        missions.forEach(mission => {
+            const tile = document.createElement('div');
+            tile.className = 'mission-tile';
+            tile.style.backgroundImage = `url('${mission.image}')`;
+            tile.dataset.minLevel = mission.minLevel;
 
-        const info = document.createElement('div');
-        info.className = 'mission-info';
-        info.innerHTML = `<div>${mission.name}</div><div>Nível ${mission.range}</div>`;
-        tile.appendChild(info);
+            const info = document.createElement('div');
+            info.className = 'mission-info';
+            info.innerHTML = `<div>${mission.name}</div><div>Nível ${mission.range}</div>`;
+            tile.appendChild(info);
 
-        const lock = document.createElement('div');
-        lock.className = 'lock-overlay';
-        lock.textContent = '🔒';
-        tile.appendChild(lock);
+            const lock = document.createElement('div');
+            lock.className = 'lock-overlay';
+            lock.textContent = '🔒';
+            tile.appendChild(lock);
 
-        grid.appendChild(tile);
+            grid.appendChild(tile);
+        });
+
+        updateLocks();
+
+        const container = document.getElementById('journey-container');
+        const titleBar = document.getElementById('title-bar');
+        const totalWidth = container.scrollWidth + 10; // small padding
+        const totalHeight = titleBar.offsetHeight + container.scrollHeight + 10;
+        window.electronAPI.send('resize-journey-window', { width: totalWidth, height: totalHeight });
     });
-
-    updateLocks();
-
-    const container = document.getElementById('journey-container');
-    const titleBar = document.getElementById('title-bar');
-    const totalWidth = container.scrollWidth + 10; // small padding
-    const totalHeight = titleBar.offsetHeight + container.scrollHeight + 10;
-    window.electronAPI.send('resize-journey-window', { width: totalWidth, height: totalHeight });
 });
 
 function updateLocks() {


### PR DESCRIPTION
## Summary
- dynamically list journey images in main process
- expose `getJourneyImages` in preload
- generate mission list from images in `journey-mode.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f176c63d8832a8736bdec78d89a05