### PR TITLE
Fix journey mode background image paths

### DIFF
--- a/main.js
+++ b/main.js
@@ -441,7 +441,7 @@ ipcMain.handle('get-journey-images', async () => {
         const dir = path.join(__dirname, 'Assets', 'Modes', 'Journeys');
         const files = await fs.promises.readdir(dir);
         return files.filter(f => /\.(png|jpg|jpeg|gif)$/i.test(f))
-            .map(f => path.join('Assets', 'Modes', 'Journeys', f));
+            .map(f => path.join('Assets', 'Modes', 'Journeys', f).replace(/\\/g, '/'));
     } catch (err) {
         console.error('Erro ao listar imagens de jornada:', err);
         return [];

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
         missions.forEach(mission => {
             const tile = document.createElement('div');
             tile.className = 'mission-tile';
-            tile.style.backgroundImage = `url('${mission.image}')`;
+            const imgPath = mission.image.replace(/\\/g, '/');
+            tile.style.backgroundImage = `url('${imgPath}')`;
             tile.dataset.minLevel = mission.minLevel;
 
             const info = document.createElement('div');


### PR DESCRIPTION
## Summary
- fix Windows-style backslashes in `get-journey-images`
- normalise paths when applying background images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f1bc567c4832a85939f89a23ed8b6