### PR TITLE
Improve journey screen loading speed

### DIFF
--- a/journey-mode.html
+++ b/journey-mode.html
@@ -17,6 +17,13 @@
         #back-journey-mode { width: 20px; height: 20px; background-color: #44aaff; border-radius: 50%; cursor: pointer; display: flex; align-items: center; justify-content: center; color: #2a435b; font-family: cursive; font-size: 12px; font-weight: bold; text-shadow: none; }
         #journey-container { padding: 10px; margin: 5px; display: flex; flex-direction: column; width: fit-content; height: fit-content; }
 
+        #loading {
+            color: #ffffff;
+            font-family: 'PixelOperator', sans-serif;
+            text-align: center;
+            margin-bottom: 10px;
+        }
+
         #missions-grid {
             display: grid;
             grid-template-columns: repeat(5, 1fr);
@@ -52,6 +59,7 @@
             </div>
         </div>
         <div id="journey-container">
+            <div id="loading">Carregando...</div>
             <div id="missions-grid"></div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -28,6 +28,7 @@ let lastUpdate = Date.now();
 let battleModeWindow = null;
 let journeyModeWindow = null;
 let trainWindow = null;
+let journeyImagesCache = null;
 
 app.whenReady().then(() => {
     console.log('Aplicativo iniciado');
@@ -437,11 +438,15 @@ ipcMain.on('set-mute-state', (event, isMuted) => {
 });
 
 ipcMain.handle('get-journey-images', async () => {
+    if (journeyImagesCache) {
+        return journeyImagesCache;
+    }
     try {
         const dir = path.join(__dirname, 'Assets', 'Modes', 'Journeys');
         const files = await fs.promises.readdir(dir);
-        return files.filter(f => /\.(png|jpg|jpeg|gif)$/i.test(f))
+        journeyImagesCache = files.filter(f => /\.(png|jpg|jpeg|gif)$/i.test(f))
             .map(f => path.join('Assets', 'Modes', 'Journeys', f).replace(/\\/g, '/'));
+        return journeyImagesCache;
     } catch (err) {
         console.error('Erro ao listar imagens de jornada:', err);
         return [];

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -14,6 +14,9 @@ document.addEventListener('DOMContentLoaded', () => {
         window.close();
     });
 
+    const loading = document.getElementById('loading');
+    const grid = document.getElementById('missions-grid');
+
     window.electronAPI.getJourneyImages().then(files => {
         const missions = files.map((img, idx) => {
             const base = img.split(/[\\/]/).pop().replace(/\.[^.]+$/, '');
@@ -23,7 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
             return { name: formatted, range, minLevel: min, image: img };
         });
 
-        const grid = document.getElementById('missions-grid');
         missions.forEach(mission => {
             const tile = document.createElement('div');
             tile.className = 'mission-tile';
@@ -43,6 +45,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
             grid.appendChild(tile);
         });
+
+        if (loading) loading.style.display = 'none';
 
         updateLocks();
 


### PR DESCRIPTION
## Summary
- cache journey images list on first fetch
- add loading indicator while missions are generated
- hide loading text when complete

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f7ec3f8832a9068645ff606d982