### PR TITLE
Add back buttons to multiple windows

### DIFF
--- a/battle-mode.html
+++ b/battle-mode.html
@@ -61,6 +61,26 @@
             font-weight: bold;
             text-shadow: none;
         }
+        #title-bar-buttons {
+            display: flex;
+            gap: 5px;
+            -webkit-app-region: no-drag;
+        }
+        #back-battle-mode {
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
 
         #battle-mode-container {
             flex: 1;
@@ -150,7 +170,10 @@
             <div id="title-bar-content">
                 <span>Modo de Batalha</span>
             </div>
-            <div id="close-battle-mode">X</div>
+            <div id="title-bar-buttons">
+                <div id="back-battle-mode">↩</div>
+                <div id="close-battle-mode">X</div>
+            </div>
         </div>
         <div id="battle-mode-container">
             <div id="mode-selection-text">Selecione o modo</div>

--- a/scripts/battle-mode.js
+++ b/scripts/battle-mode.js
@@ -10,6 +10,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Adicionar evento ao botão de fechar
     document.getElementById('close-battle-mode')?.addEventListener('click', closeWindow);
+    document.getElementById('back-battle-mode')?.addEventListener('click', closeWindow);
 
     // Adicionar eventos pras divs de modo
     const modeJourney = document.getElementById('mode-journey');

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -206,4 +206,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Adicionar evento ao botão de fechar
     document.getElementById('close-status-titlebar')?.addEventListener('click', closeWindow);
+    document.getElementById('back-status-titlebar')?.addEventListener('click', () => {
+        closeWindow();
+    });
 });

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -8,6 +8,10 @@ function closeWindow() {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.getElementById('close-train-window')?.addEventListener('click', closeWindow);
+    document.getElementById('back-train-window')?.addEventListener('click', () => {
+        window.electronAPI.send('open-status-window');
+        closeWindow();
+    });
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;

--- a/status.html
+++ b/status.html
@@ -80,6 +80,26 @@
             font-weight: bold;
             text-shadow: none;
         }
+        #title-bar-buttons {
+            display: flex;
+            gap: 5px;
+            -webkit-app-region: no-drag;
+        }
+        #back-status-titlebar {
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
 
         #status-container {
             flex: 1;
@@ -373,7 +393,10 @@
                 <img id="title-bar-element" src="Assets/Elements/default.png" alt="Elemento">
                 <span id="title-bar-pet-name">Nome do Pet</span>
             </div>
-            <div id="close-status-titlebar">X</div>
+            <div id="title-bar-buttons">
+                <div id="back-status-titlebar">↩</div>
+                <div id="close-status-titlebar">X</div>
+            </div>
         </div>
         <div id="status-container">
             <div id="status-content">

--- a/train.html
+++ b/train.html
@@ -50,6 +50,26 @@
             font-weight: bold;
             text-shadow: none;
         }
+        #title-bar-buttons {
+            display: flex;
+            gap: 5px;
+            -webkit-app-region: no-drag;
+        }
+        #back-train-window {
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
         #train-container { flex:1; padding:0; overflow-y:auto; }
         table { width:100%; border-collapse:collapse; table-layout:fixed; }
         th, td { border:1px solid #2a323e; padding:4px; text-align:center; font-size:14px; }
@@ -67,7 +87,10 @@
     <div class="window">
         <div id="title-bar">
             <div id="title-bar-content"><span>Treinar Golpes</span></div>
-            <div id="close-train-window">X</div>
+            <div id="title-bar-buttons">
+                <div id="back-train-window">↩</div>
+                <div id="close-train-window">X</div>
+            </div>
         </div>
         <div id="train-container">
             <table id="moves-table">


### PR DESCRIPTION
## Summary
- add back button in battle-mode window
- allow returning from training screen
- add back button to pet status window

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f25da732c832abad80b16c6faa945