### PR TITLE
Add back button to train screen

### DIFF
--- a/scripts/train.js
+++ b/scripts/train.js
@@ -12,6 +12,10 @@ document.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.send('open-status-window');
         closeWindow();
     });
+    document.getElementById('back-button')?.addEventListener('click', () => {
+        window.electronAPI.send('open-status-window');
+        closeWindow();
+    });
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;

--- a/train.html
+++ b/train.html
@@ -109,6 +109,7 @@
                 <tbody></tbody>
             </table>
         </div>
+        <button class="button" id="back-button">Voltar</button>
     </div>
     <script src="scripts/train.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a visible **Voltar** button to `train.html`
- close the training window and open the status window when the new button is clicked

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f27c901a4832a885614f82fffd5e9