### PR TITLE
Overlay bio image when viewing pet about tab

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -59,6 +59,7 @@ function updateStatus() {
     const statusLevel = document.getElementById('status-level');
     const statusMoves = document.getElementById('status-moves');
     const statusPetImage = document.getElementById('status-pet-image');
+    const statusBioImage = document.getElementById('status-bio-image');
     const bioImage = document.getElementById('bio-image');
     const bioText = document.getElementById('bio-text');
     const titleBarElement = document.getElementById('title-bar-element');
@@ -66,7 +67,7 @@ function updateStatus() {
     const statusPetImageGradient = document.getElementById('status-pet-image-gradient');
 
     // Verificar se todos os elementos estão disponíveis
-    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusMoves || !statusPetImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioImage || !bioText) {
+    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioImage || !bioText) {
         console.error('Um ou mais elementos do status-container ou title-bar não encontrados', {
             healthContainer: !!healthContainer,
             hungerContainer: !!hungerContainer,
@@ -84,6 +85,7 @@ function updateStatus() {
             statusLevel: !!statusLevel,
             statusMoves: !!statusMoves,
             statusPetImage: !!statusPetImage,
+            statusBioImage: !!statusBioImage,
             titleBarElement: !!titleBarElement,
             titleBarPetName: !!titleBarPetName,
             statusPetImageGradient: !!statusPetImageGradient
@@ -185,6 +187,15 @@ function updateStatus() {
         setImageWithFallback(statusPetImage, pet.image);
     }
 
+    if (statusBioImage) {
+        if (pet.bioImage) {
+            statusBioImage.src = `Assets/Mons/${pet.bioImage}`;
+        } else {
+            statusBioImage.src = '';
+        }
+        statusBioImage.style.display = 'none';
+    }
+
     const activeBtn = document.querySelector('.tab-button.active');
     if (activeBtn) {
         const tabId = activeBtn.getAttribute('data-tab');
@@ -198,19 +209,15 @@ function closeWindow() {
 }
 
 function updateTabImage(tabId) {
-    const statusPetImage = document.getElementById('status-pet-image');
-    if (!statusPetImage) return;
+    const statusBioImage = document.getElementById('status-bio-image');
+    if (!statusBioImage) return;
 
     if (tabId === 'tab-sobre') {
         if (pet.bioImage) {
-            setImageWithFallback(statusPetImage, pet.bioImage);
+            statusBioImage.style.display = 'block';
         }
     } else {
-        if (pet.statusImage) {
-            setImageWithFallback(statusPetImage, pet.statusImage);
-        } else {
-            setImageWithFallback(statusPetImage, pet.image);
-        }
+        statusBioImage.style.display = 'none';
     }
 }
 

--- a/status.html
+++ b/status.html
@@ -164,6 +164,18 @@
             z-index: 3;
         }
 
+        #status-bio-image {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 256px;
+            height: 256px;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            z-index: 4;
+            display: none;
+        }
+
         #status-rarity-label {
             position: absolute;
             bottom: 5px;
@@ -412,6 +424,7 @@
                         <div id="status-pet-image-gradient"></div>
                         <div id="status-pet-image-texture"></div>
                         <img id="status-pet-image" src="Assets/Mons/eggsy.png" alt="Pet">
+                        <img id="status-bio-image" src="" alt="Bio do Pet">
                         <div id="status-rarity-label">RARIDADE</div>
                         <div id="status-level">Level: 0</div>
                     </div>


### PR DESCRIPTION
## Summary
- show bio image over the regular pet status picture when the Sobre tab is active

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f7cd6eb4c832a9aa7a5f33b6adc54