### PR TITLE
Handle new pet folder structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ O comando `npm start` executa `electron .` abrindo a janela inicial (`start.html
 
 - Na tela inicial é possível **criar** um novo pet ou **carregar** um existente.
 - Os dados dos pets ficam salvos no diretório `pets/`.
+- As imagens de cada pet ficam organizadas em pastas dentro de `Assets/Mons/`. Caso não exista uma pasta específica para um pet, a imagem `eggsy.png` é utilizada como padrão.
 - O atalho `Ctrl+Shift+D` abre as ferramentas de desenvolvedor do Electron.
 
 O projeto utiliza `electron-store` para persistência de algumas informações e

--- a/index.html
+++ b/index.html
@@ -370,7 +370,7 @@
             healthFill.style.width = `${(petData.currentHealth / petData.maxHealth || 0) * 100}%`;
             energyFill.style.width = `${petData.energy || 0}%`;
             levelDisplay.textContent = `Lvl ${petData.level || 1}`;
-            petImage.src = petData.image ? `Assets/Mons/${petData.image}` : 'Assets/Mons/eggsy.png';
+            petImage.src = petData.statusImage ? `Assets/Mons/${petData.statusImage}` : (petData.image ? `Assets/Mons/${petData.image}` : 'Assets/Mons/eggsy.png');
             petImageBackground.style.background = rarityGradients[petData.rarity] || rarityGradients['Comum'];
             petName.textContent = petData.name || 'Eggsy';
 

--- a/load-pet.html
+++ b/load-pet.html
@@ -199,7 +199,7 @@
                         <div class="pet-image-container">
                             <div class="pet-image-background"></div>
                             <div class="pet-image-texture"></div>
-                            <img src="${pet.image ? `Assets/Mons/${pet.image}` : 'Assets/Mons/eggsy.png'}" alt="${pet.name}" />
+                            <img src="${pet.statusImage ? `Assets/Mons/${pet.statusImage}` : (pet.image ? `Assets/Mons/${pet.image}` : 'Assets/Mons/eggsy.png')}" alt="${pet.name}" />
                         </div>
                         <div class="pet-info">
                             <p><strong>Nome:</strong> ${pet.name}</p>


### PR DESCRIPTION
## Summary
- document new monster folder layout
- default to statusImage when showing pet images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f7db2b67c832ab97ca9cdf045a6bf