### PR TITLE
Fix bio image fallback

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -6,3 +6,16 @@ export const rarityGradients = {
     'Epico': 'linear-gradient(135deg, #800080, #DA70D6)',
     'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
 };
+
+// Caminho da imagem em alta resolução de cada espécie para ser exibida na aba
+// "Sobre". Utilizada como fallback quando o pet não define uma imagem de bio
+// específica.
+export const specieBioImages = {
+    'Draconídeo': 'Draconideo/draconideo.png',
+    'Reptilóide': 'Reptiloide/puro/viborom/reptiloide.png',
+    'Ave': 'Ave/ave.png',
+    'Criatura Mística': 'CriaturaMistica/CriaturaMistica.png',
+    'Criatura Sombria': 'CriaturaSombria/criaturasombria.png',
+    'Monstro': 'Monstro/monstro.png',
+    'Fera': 'Fera/fera.png'
+};

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -20,6 +20,14 @@ const specieImages = Object.fromEntries(
     })
 );
 
+// Imagem em alta resolução de cada espécie para exibir na seção de biografia
+const specieBioImages = Object.fromEntries(
+    Object.entries(specieData).map(([key, value]) => {
+        const fileName = `${value.dir.toLowerCase()}.png`;
+        return [key, `${value.dir}/${fileName}`];
+    })
+);
+
 // Perguntas carregadas de data/questions.json
 
 let questions = [];
@@ -226,14 +234,13 @@ function showNameSelection(element) {
         const image = specieImages[specie] || 'eggsy.png';
 
         let race = null;
-        let bioImage = null;
+        let bioImage = specieBioImages[specie] || null;
         let statusImage = null;
         const info = specieData[specie];
         if (info) {
             race = info.race || null;
             if (info.race) {
                 const base = info.element ? `${info.dir}/${info.element}/${info.race}` : `${info.dir}/${info.race}`;
-                bioImage = `${base}/${info.race}.png`;
                 statusImage = `${base}/front.gif`;
             }
         }

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,4 +1,4 @@
-import { rarityGradients } from './constants.js';
+import { rarityGradients, specieBioImages } from './constants.js';
 console.log('status.js carregado com sucesso');
 
 let pet = {};
@@ -182,8 +182,9 @@ function updateStatus() {
     }
 
     if (statusBioImage) {
-        if (pet.bioImage) {
-            statusBioImage.src = `Assets/Mons/${pet.bioImage}`;
+        const bioPath = pet.bioImage || specieBioImages[pet.specie];
+        if (bioPath) {
+            statusBioImage.src = `Assets/Mons/${bioPath}`;
         } else {
             statusBioImage.src = '';
         }
@@ -207,7 +208,8 @@ function updateTabImage(tabId) {
     if (!statusBioImage) return;
 
     if (tabId === 'tab-sobre') {
-        if (pet.bioImage) {
+        const bioPath = pet.bioImage || specieBioImages[pet.specie];
+        if (bioPath) {
             statusBioImage.style.display = 'block';
         }
     } else {

--- a/start.html
+++ b/start.html
@@ -19,6 +19,10 @@
             width: 520px;
             z-index: 0;
             top: 15px;
+            image-rendering: pixelated;
+            image-rendering: crisp-edges;
+            image-rendering: -moz-crisp-edges;
+            image-rendering: -webkit-optimize-contrast;
         }
 
         .button {

--- a/styles/main.css
+++ b/styles/main.css
@@ -27,6 +27,14 @@ body {
     align-items: center;
 }
 
+/* Garantir que todas as imagens sejam exibidas com pixels nítidos */
+img {
+    image-rendering: pixelated;
+    image-rendering: crisp-edges;
+    image-rendering: -moz-crisp-edges;
+    image-rendering: -webkit-optimize-contrast;
+}
+
 /* Estilo da janela principal */
 .window {
     width: 100%;


### PR DESCRIPTION
## Summary
- add specieBioImages constant
- pick specieBioImages when creating a pet
- show specieBioImages in status window if bio image missing
- ensure images render pixel-perfect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684f829d891c832abcea73f5a7062746