### PR TITLE
Adjust pet item image layout

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -48,6 +48,9 @@
             width: 128px;
             height: 128px;
             margin-right: 20px;
+            display: flex;
+            align-items: flex-end; /* posiciona itens no bottom */
+            justify-content: center; /* centraliza horizontalmente */
         }
 
         .pet-image-background {
@@ -77,10 +80,11 @@
 
         .pet-item img {
             position: relative;
-            width: 100%;
-            height: 100%;
+            width: 96px;
+            height: 96px;
             border-radius: 7px;
             z-index: 3;
+            image-rendering: pixelated;
         }
 
         .pet-info {


### PR DESCRIPTION
## Summary
- tweak pet item image container to align bottom and center
- size pet list images consistently and enforce pixel rendering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850450c8408832ab826112c405a9d7a