### PR TITLE
Update image style for non-gif pets

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -84,7 +84,13 @@
             height: 96px;
             border-radius: 7px;
             z-index: 3;
+        }
+
+        /* Imagens que não são GIF usam estilo pixelado e tamanho maior */
+        .pet-item img:not([src$=".gif"]) {
             image-rendering: pixelated;
+            width: 160px;
+            height: 160px;
         }
 
         .pet-info {


### PR DESCRIPTION
## Summary
- adjust image styles on the load-pet page so that non-GIF images are pixelated and larger

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_6850464c2938832a9f5ca562a3d2f26f