### PR TITLE
Apply rarity color on status image

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -7,6 +7,15 @@ export const rarityGradients = {
     'Lendario': 'linear-gradient(135deg, #FFD700, #FFA500)'
 };
 
+export const rarityColors = {
+    'Comum': '#808080',
+    'Incomum': '#D3D3D3',
+    'Raro': '#32CD32',
+    'MuitoRaro': '#4682B4',
+    'Epico': '#800080',
+    'Lendario': '#FFD700'
+};
+
 // Caminho da imagem em alta resolução de cada espécie para ser exibida na aba
 // "Sobre". Utilizada como fallback quando o pet não define uma imagem de bio
 // específica.

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,4 +1,4 @@
-import { rarityGradients, specieBioImages } from './constants.js';
+import { rarityGradients, rarityColors, specieBioImages } from './constants.js';
 console.log('status.js carregado com sucesso');
 
 let pet = {};
@@ -169,6 +169,9 @@ function updateStatus() {
     const gradient = rarityGradients[pet.rarity] || 'linear-gradient(135deg, #808080, #A9A9A9)';
     console.log('Aplicando gradiente:', gradient);
     statusPetImageGradient.style.background = gradient;
+
+    const borderColor = rarityColors[pet.rarity] || '#808080';
+    statusPetImage.style.borderColor = borderColor;
 
     // Atualizar a imagem do pet
     statusPetImage.addEventListener('load', () => {


### PR DESCRIPTION
## Summary
- add `rarityColors` constants
- apply rarity color to `#status-pet-image` border

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685069eaa63c832aa8945e9b1f81245c