### PR TITLE
Adjust pet image styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -49,8 +49,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 256px;
+            height: 256px;
             background: linear-gradient(135deg, #808080, #A9A9A9);
             border-radius: 7px;
             z-index: 1;
@@ -60,8 +60,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 256px;
+            height: 256px;
             background: url('Assets/Rarity/texture.png');
             background-size: cover;
             opacity: 1;
@@ -75,6 +75,13 @@
             height: 100%;
             border-radius: 7px;
             z-index: 3;
+        }
+
+        #pet-image {
+            position: absolute;
+            bottom: 0;
+            left: 50%;
+            transform: translateX(-50%);
         }
 
         .pet-info {

--- a/load-pet.html
+++ b/load-pet.html
@@ -57,8 +57,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 256px;
+            height: 256px;
             background: linear-gradient(135deg, #808080, #A9A9A9); /* Padrão para Comum */
             border-radius: 7px;
             z-index: 1;
@@ -68,8 +68,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 100%;
-            height: 100%;
+            width: 256px;
+            height: 256px;
             background: url('Assets/Rarity/texture.png');
             background-size: cover;
             opacity: 0.5;


### PR DESCRIPTION
## Summary
- set the background and texture containers to 256px
- center the main pet image at the bottom of its container

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68506b9e4e18832abf3805d146cf0cf4