### PR TITLE
Update overlay sizes in load-pet page

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -57,8 +57,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 256px;
-            height: 256px;
+            width: 130px;
+            height: 130px;
             background: linear-gradient(135deg, #808080, #A9A9A9); /* Padrão para Comum */
             border-radius: 7px;
             z-index: 1;
@@ -68,8 +68,8 @@
             position: absolute;
             top: 0;
             left: 0;
-            width: 256px;
-            height: 256px;
+            width: 130px;
+            height: 130px;
             background: url('Assets/Rarity/texture.png');
             background-size: cover;
             opacity: 0.5;


### PR DESCRIPTION
## Summary
- adjust `.pet-image-background` and `.pet-image-texture` to 130px square on load pet screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507a3c2d9c832ab404e6c7cf14893c