### PR TITLE
Apply user feedback for pet images

### DIFF
--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -231,11 +231,9 @@ function showNameSelection(element) {
         const rarity = generateRarity();
 
         // Definir a imagem e demais caminhos de acordo com a espécie
-        const image = specieImages[specie] || 'eggsy.png';
-
         let race = null;
-        let bioImage = specieBioImages[specie] || null;
         let statusImage = null;
+        let bioImage = `${name}.png`;
         const info = specieData[specie];
         if (info) {
             race = info.race || null;
@@ -244,6 +242,10 @@ function showNameSelection(element) {
                 statusImage = `${base}/front.gif`;
             }
         }
+        if (!statusImage) {
+            statusImage = specieImages[specie] || 'eggsy.png';
+        }
+        const image = statusImage;
 
         const petData = {
             name,

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -42,19 +42,33 @@ async function savePetCounter() {
 }
 
 function ensureStatusImage(pet) {
-    if (pet.statusImage || !pet.image) return;
+    const basePath = pet.statusImage || pet.image;
+    const relativeDir = basePath ? path.posix.dirname(basePath) : null;
 
-    const relativeDir = path.posix.dirname(pet.image);
-    if (!relativeDir || relativeDir === '.') return;
+    if (relativeDir && relativeDir !== '.') {
+        if (!pet.statusImage) {
+            const baseDir = path.join(__dirname, '..', 'Assets', 'Mons', relativeDir);
+            const gifPath = path.join(baseDir, 'front.gif');
+            const pngPath = path.join(baseDir, 'front.png');
 
-    const baseDir = path.join(__dirname, '..', 'Assets', 'Mons', relativeDir);
-    const gifPath = path.join(baseDir, 'front.gif');
-    const pngPath = path.join(baseDir, 'front.png');
+            if (fsSync.existsSync(gifPath)) {
+                pet.statusImage = path.posix.join(relativeDir, 'front.gif');
+            } else if (fsSync.existsSync(pngPath)) {
+                pet.statusImage = path.posix.join(relativeDir, 'front.png');
+            }
+        }
+    }
 
-    if (fsSync.existsSync(gifPath)) {
-        pet.statusImage = path.posix.join(relativeDir, 'front.gif');
-    } else if (fsSync.existsSync(pngPath)) {
-        pet.statusImage = path.posix.join(relativeDir, 'front.png');
+    if (!pet.statusImage && pet.image) {
+        pet.statusImage = pet.image;
+    }
+
+    if (pet.statusImage) {
+        pet.image = pet.statusImage;
+    }
+
+    if (!pet.bioImage) {
+        pet.bioImage = `${pet.name}.png`;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure pets default to a status image and use it as their main image
- use pet names for bio image paths
- adjust pet manager so image and status image always match

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850a708349c832a971fb5eff8978d18