### PR TITLE
Add move description panel

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -1,6 +1,7 @@
 [
   {
     "name": "Arranhão",
+    "description": "Ataque básico que causa dano leve ao inimigo.",
     "rarity": "Comum",
     "elements": ["fogo", "agua", "terra", "ar", "puro"],
     "species": ["Draconídeo", "Ave", "Fera"],
@@ -11,6 +12,7 @@
   },
   {
     "name": "Mordida",
+    "description": "Crava os dentes no alvo para causar dano moderado.",
     "rarity": "Comum",
     "elements": ["fogo", "agua", "terra", "ar", "puro"],
     "species": ["Draconídeo", "Fera", "Reptilóide"],
@@ -21,6 +23,7 @@
   },
   {
     "name": "Empurrar",
+    "description": "Empurra o adversário para afastá-lo causando leve dano.",
     "rarity": "Comum",
     "elements": ["fogo", "agua", "terra", "ar", "puro"],
     "species": ["Ave", "Reptilóide", "Monstro"],
@@ -31,6 +34,7 @@
   },
   {
     "name": "Pulso",
+    "description": "Emite um pulso de energia que causa dano padrao.",
     "rarity": "Comum",
     "elements": ["fogo", "agua", "terra", "ar", "puro"],
     "species": ["Criatura Mística", "Criatura Sombria", "Monstro"],
@@ -41,6 +45,7 @@
   },
   {
     "name": "Olhar",
+    "description": "Lanca um olhar intimidador causando dano minimo.",
     "rarity": "Comum",
     "elements": ["fogo", "agua", "terra", "ar", "puro"],
     "species": ["Criatura Mística", "Criatura Sombria"],
@@ -51,6 +56,7 @@
   },
   {
     "name": "Asas de Brasa",
+    "description": "Investida com asas em chamas que pode queimar o alvo.",
     "rarity": "Raro",
     "elements": ["fogo"],
     "species": ["Ave"],
@@ -61,6 +67,7 @@
   },
   {
     "name": "Mordida Sombria",
+    "description": "Mordida impregnada de energia sombria que pode envenenar.",
     "rarity": "Incomum",
     "elements": ["terra"],
     "species": ["Fera", "Monstro", "Criatura Sombria"],

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -3,6 +3,8 @@ console.log('status.js carregado com sucesso');
 
 let pet = {};
 
+let descriptionEl = null;
+
 function setImageWithFallback(imgElement, relativePath) {
     if (!imgElement) return;
     if (!relativePath) {
@@ -141,6 +143,13 @@ function updateStatus() {
         slot.className = 'move-slot';
         if (pet.moves && pet.moves[i]) {
             slot.textContent = pet.moves[i].name;
+            const desc = pet.moves[i].description || '';
+            slot.addEventListener('mouseenter', () => {
+                if (descriptionEl) descriptionEl.textContent = desc;
+            });
+            slot.addEventListener('mouseleave', () => {
+                if (descriptionEl) descriptionEl.textContent = '';
+            });
         } else {
             const btn = document.createElement('button');
             btn.className = 'button add-move-button';
@@ -222,6 +231,8 @@ function updateTabImage(tabId) {
 
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOM carregado na janela de status');
+
+    descriptionEl = document.getElementById('move-description');
 
     // Controle das abas
     document.querySelectorAll('.tab-button').forEach(button => {

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -2,6 +2,8 @@ console.log('train.js carregado');
 
 let pet = null;
 
+let descriptionEl = null;
+
 function closeWindow() {
     window.close();
 }
@@ -12,6 +14,8 @@ document.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.send('open-status-window');
         closeWindow();
     });
+
+    descriptionEl = document.getElementById('move-description');
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
@@ -37,6 +41,12 @@ function renderMoves(moves) {
             return;
         }
         const tr = document.createElement('tr');
+        tr.addEventListener('mouseenter', () => {
+            if (descriptionEl) descriptionEl.textContent = move.description || '';
+        });
+        tr.addEventListener('mouseleave', () => {
+            if (descriptionEl) descriptionEl.textContent = '';
+        });
         let action = 'Aprender';
         const known = pet.moves && pet.moves.some(m => m.name === move.name);
         if (known) action = 'Reaprender';

--- a/status.html
+++ b/status.html
@@ -407,6 +407,15 @@
             /* Forçar o comportamento */
             opacity: 1;
         }
+
+        #move-description {
+            margin: 8px;
+            padding: 4px;
+            min-height: 24px;
+            background: #2a323e;
+            color: #fff;
+            font-size: 14px;
+        }
     </style>
 </head>
 
@@ -492,6 +501,7 @@
                     <div id="tab-moves" class="tab-content-item">
                         <div id="status-moves"></div>
                         <button class="button small-button" id="train-moves-button">Treinar</button>
+                        <div id="move-description"></div>
                     </div>
                     <div id="tab-sobre" class="tab-content-item">
                         <p id="bio-text" style="text-align:center;"></p>

--- a/train.html
+++ b/train.html
@@ -78,6 +78,15 @@
         .action-reaprender { background-color:#3498db; }
         .action-trocar { background-color:#f1c40f; }
         .action-indisponivel { background-color:#7f8c8d; }
+
+        #move-description {
+            margin: 8px;
+            padding: 4px;
+            min-height: 24px;
+            background: #2a323e;
+            color: #fff;
+            font-size: 14px;
+        }
     </style>
 </head>
 <body>
@@ -105,6 +114,7 @@
                 </thead>
                 <tbody></tbody>
             </table>
+            <div id="move-description"></div>
         </div>
     </div>
     <script src="scripts/train.js"></script>


### PR DESCRIPTION
## Summary
- replace custom tooltip with fixed description area
- update training and status pages to include #move-description container
- display move descriptions when hovering move rows or slots

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685164cdc5d0832abc6504079eb946f4