### PR TITLE
Fix move tooltip display

### DIFF
--- a/scripts/train.js
+++ b/scripts/train.js
@@ -41,7 +41,6 @@ function renderMoves(moves) {
             return;
         }
         const tr = document.createElement('tr');
- l7plw5-codex/adicionar-tooltip-com-descrição-do-golpe
         tr.addEventListener('mouseenter', () => {
             if (descriptionEl) descriptionEl.textContent = move.description || '';
         });


### PR DESCRIPTION
## Summary
- remove invalid leftover text from `scripts/train.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68517052c834832a8c9e234d80bf4ed5