### PR TITLE
Enable move description tooltip

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -5,6 +5,20 @@ let pet = {};
 
 let descriptionEl = null;
 
+function showDescription(text, evt) {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = text;
+    descriptionEl.style.left = `${evt.pageX + 10}px`;
+    descriptionEl.style.top = `${evt.pageY + 10}px`;
+    descriptionEl.style.visibility = 'visible';
+}
+
+function hideDescription() {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = '';
+    descriptionEl.style.visibility = 'hidden';
+}
+
 function setImageWithFallback(imgElement, relativePath) {
     if (!imgElement) return;
     if (!relativePath) {
@@ -144,12 +158,16 @@ function updateStatus() {
         if (pet.moves && pet.moves[i]) {
             slot.textContent = pet.moves[i].name;
             const desc = pet.moves[i].description || '';
-            slot.addEventListener('mouseenter', () => {
-                if (descriptionEl) descriptionEl.textContent = desc;
+            slot.addEventListener('mouseenter', (e) => {
+                showDescription(desc, e);
             });
-            slot.addEventListener('mouseleave', () => {
-                if (descriptionEl) descriptionEl.textContent = '';
+            slot.addEventListener('mousemove', (e) => {
+                if (descriptionEl && descriptionEl.style.visibility === 'visible') {
+                    descriptionEl.style.left = `${e.pageX + 10}px`;
+                    descriptionEl.style.top = `${e.pageY + 10}px`;
+                }
             });
+            slot.addEventListener('mouseleave', hideDescription);
         } else {
             const btn = document.createElement('button');
             btn.className = 'button add-move-button';

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -4,6 +4,20 @@ let pet = null;
 
 let descriptionEl = null;
 
+function showDescription(text, evt) {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = text;
+    descriptionEl.style.left = `${evt.pageX + 10}px`;
+    descriptionEl.style.top = `${evt.pageY + 10}px`;
+    descriptionEl.style.visibility = 'visible';
+}
+
+function hideDescription() {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = '';
+    descriptionEl.style.visibility = 'hidden';
+}
+
 function closeWindow() {
     window.close();
 }
@@ -41,12 +55,16 @@ function renderMoves(moves) {
             return;
         }
         const tr = document.createElement('tr');
-        tr.addEventListener('mouseenter', () => {
-            if (descriptionEl) descriptionEl.textContent = move.description || '';
+        tr.addEventListener('mouseenter', (e) => {
+            showDescription(move.description || '', e);
         });
-        tr.addEventListener('mouseleave', () => {
-            if (descriptionEl) descriptionEl.textContent = '';
+        tr.addEventListener('mousemove', (e) => {
+            if (descriptionEl && descriptionEl.style.visibility === 'visible') {
+                descriptionEl.style.left = `${e.pageX + 10}px`;
+                descriptionEl.style.top = `${e.pageY + 10}px`;
+            }
         });
+        tr.addEventListener('mouseleave', hideDescription);
 
         let action = 'Aprender';
         const known = pet.moves && pet.moves.some(m => m.name === move.name);

--- a/status.html
+++ b/status.html
@@ -409,12 +409,16 @@
         }
 
         #move-description {
-            margin: 8px;
-            padding: 4px;
-            min-height: 24px;
+            position: fixed;
+            pointer-events: none;
+            visibility: hidden;
+            padding: 4px 8px;
             background: #2a323e;
             color: #fff;
             font-size: 14px;
+            border-radius: 4px;
+            z-index: 1000;
+            white-space: nowrap;
         }
     </style>
 </head>

--- a/train.html
+++ b/train.html
@@ -80,12 +80,16 @@
         .action-indisponivel { background-color:#7f8c8d; }
 
         #move-description {
-            margin: 8px;
-            padding: 4px;
-            min-height: 24px;
+            position: fixed;
+            pointer-events: none;
+            visibility: hidden;
+            padding: 4px 8px;
             background: #2a323e;
             color: #fff;
             font-size: 14px;
+            border-radius: 4px;
+            z-index: 1000;
+            white-space: nowrap;
         }
     </style>
 </head>


### PR DESCRIPTION
## Summary
- style the move description as a hidden tooltip
- show/hide the tooltip on mouse hover in training and status pages

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851719a8058832a9c33a519aea13424