### PR TITLE
Add rarity badge to training table

### DIFF
--- a/scripts/train.js
+++ b/scripts/train.js
@@ -1,3 +1,4 @@
+import { rarityGradients } from './constants.js';
 console.log('train.js carregado');
 
 let pet = null;
@@ -91,9 +92,10 @@ function renderMoves(moves) {
                 actionClass = 'action-indisponivel';
         }
 
+        const rarityStyle = rarityGradients[move.rarity] || rarityGradients['Comum'];
         tr.innerHTML = `
             <td>${move.name}</td>
-            <td>${move.rarity}</td>
+            <td><span style="padding: 5px; background: ${rarityStyle}; border-radius: 5px;">${move.rarity}</span></td>
             <td>${elementIcons}</td>
             <td>${move.power}</td>
             <td>${move.effect}</td>

--- a/train.html
+++ b/train.html
@@ -121,6 +121,6 @@
             <div id="move-description"></div>
         </div>
     </div>
-    <script src="scripts/train.js"></script>
+    <script type="module" src="scripts/train.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- make `train.js` a module and import shared rarity gradients
- display rarity with colored badge

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685174a4c23c832abc1f3df4a9658141