### PR TITLE
Update journey level logic

### DIFF
--- a/journey-mode.html
+++ b/journey-mode.html
@@ -47,6 +47,7 @@
         .mission-info { background-color: rgba(0,0,0,0.5); width: 100%; text-align: center; color: #ffffff; font-family: 'PixelOperator', sans-serif; padding: 2px 0; }
         .lock-overlay { position: absolute; top: 0; left: 0; width: 100%; height: 100%; background-color: rgba(0,0,0,0.6); display: none; align-items: center; justify-content: center; font-size: 32px; }
         .mission-tile.locked .lock-overlay { display: flex; }
+        .mission-tile.locked .mission-info { color: red; }
     </style>
 </head>
 <body>

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -5,9 +5,9 @@ console.log('journey-mode.js carregado');
 // Assets/Modes/Journeys sem a extensão.
 const journeyLevels = {
     forest: 1,
-    lake: 6,
-    mountain: 11,
-    abyss: 16
+    lake: 4,
+    mountain: 7,
+    abyss: 10
 };
 
 let petLevel = 1;
@@ -32,9 +32,10 @@ document.addEventListener('DOMContentLoaded', () => {
             const base = img.split(/[\\/]/).pop().replace(/\.[^.]+$/, '');
             const formatted = base.replace(/[-_]+/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
             const mapped = journeyLevels[base.toLowerCase()];
-            const min = mapped !== undefined ? mapped : idx * 5 + 1;
-            const range = `${min}~${min + 4}`;
-            return { name: formatted, range, minLevel: min, image: img };
+            const min = mapped !== undefined ? mapped : idx * 3 + 1;
+            const max = min + 2;
+            const range = `${min}~${max}`;
+            return { name: formatted, range, minLevel: min, maxLevel: max, image: img };
         });
 
         missions.forEach(mission => {
@@ -43,6 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const imgPath = mission.image.replace(/\\/g, '/');
             tile.style.backgroundImage = `url('${imgPath}')`;
             tile.dataset.minLevel = mission.minLevel;
+            tile.dataset.maxLevel = mission.maxLevel;
 
             const info = document.createElement('div');
             info.className = 'mission-info';
@@ -71,8 +73,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
 function updateLocks() {
     document.querySelectorAll('.mission-tile').forEach(tile => {
-        const required = parseInt(tile.dataset.minLevel, 10);
-        if (petLevel < required) {
+        const min = parseInt(tile.dataset.minLevel, 10);
+        const max = parseInt(tile.dataset.maxLevel, 10);
+        if (petLevel < min || petLevel > max) {
             tile.classList.add('locked');
         } else {
             tile.classList.remove('locked');


### PR DESCRIPTION
## Summary
- refine ranges for journey missions
- lock missions when pet level is outside the mission range
- color locked mission names in red

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: electron not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851c9d7b2b8832a8a5426261e2ea02e