### PR TITLE
Adjust journey scene positions

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -30,12 +30,12 @@
         }
         .pet {
             position: absolute;
-            bottom: 20px;
-            width: 200px;
+            bottom: 120px;
+            width: 150px;
             image-rendering: pixelated;
         }
-        #player-pet { left: 50px; }
-        #enemy-pet { right: 50px; transform: scaleX(-1); }
+        #player-pet { left: 100px; transform: scaleX(-1); }
+        #enemy-pet { right: 100px; transform: scaleX(1); }
     </style>
 </head>
 <body>

--- a/main.js
+++ b/main.js
@@ -427,7 +427,7 @@ ipcMain.on('open-journey-scene-window', async (event, data) => {
     console.log('Recebido open-journey-scene-window');
     const win = createJourneySceneWindow();
     if (!win) return;
-    const enemy = await getRandomEnemyFront(currentPet ? currentPet.statusImage : null);
+    const enemy = await getRandomEnemyIdle(currentPet ? currentPet.statusImage : null);
     win.webContents.on('did-finish-load', () => {
         win.webContents.send('scene-data', {
             background: data.background,
@@ -494,10 +494,10 @@ ipcMain.handle('get-journey-images', async () => {
     }
 });
 
-let frontGifsCache = null;
+let idleGifsCache = null;
 
-async function loadFrontGifs() {
-    if (frontGifsCache) return frontGifsCache;
+async function loadIdleGifs() {
+    if (idleGifsCache) return idleGifsCache;
     const dir = path.join(__dirname, 'Assets', 'Mons');
     const result = [];
     async function walk(folder) {
@@ -506,18 +506,18 @@ async function loadFrontGifs() {
             const full = path.join(folder, entry.name);
             if (entry.isDirectory()) {
                 await walk(full);
-            } else if (entry.isFile() && entry.name.toLowerCase() === 'front.gif') {
+            } else if (entry.isFile() && entry.name.toLowerCase() === 'idle.gif') {
                 result.push(full.replace(/\\/g, '/'));
             }
         }
     }
     await walk(dir);
-    frontGifsCache = result;
-    return frontGifsCache;
+    idleGifsCache = result;
+    return idleGifsCache;
 }
 
-async function getRandomEnemyFront(exclude) {
-    const list = await loadFrontGifs();
+async function getRandomEnemyIdle(exclude) {
+    const list = await loadIdleGifs();
     let filtered = list;
     if (exclude) {
         const normalized = exclude.replace(/\\/g, '/');


### PR DESCRIPTION
## Summary
- place player pet on the left and enemy on the right in journey scene
- lift both sprites 120px from the bottom

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851def6dba8832aba95ff7c2ca013c6