### PR TITLE
Adjust journey scene HUD

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -52,15 +52,31 @@
             height: 70px;
             image-rendering: pixelated;
         }
+        .hud-front {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        .pet-name {
+            color: #ffffff;
+            font-family: 'PixelOperator', sans-serif;
+            font-size: 15px;
+            padding: 2px 5px;
+            border-radius: 3px;
+            margin-bottom: 3px;
+            font-weight: bold;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
+        }
         .hud-bars {
             display: flex;
             flex-direction: column;
-            margin: 0 5px;
+            margin: 0 28px;
+            width: 300px;
         }
         .health-bar,
         .energy-bar {
-            width: 50px;
-            height: 6px;
+            width: 300px;
+            height: 13px;
             background-color: #444;
             border: 1px solid #fff;
             border-radius: 3px;
@@ -97,7 +113,10 @@
         </div>
 
         <div id="enemy-hud" class="hud-container">
-            <img id="enemy-front" class="hud-pet" src="" alt="inimigo">
+            <div class="hud-front">
+                <img id="enemy-front" class="hud-pet" src="" alt="inimigo">
+                <div id="enemy-name" class="pet-name"></div>
+            </div>
             <div class="hud-bars">
                 <div class="health-bar">
                     <div class="bar" id="enemy-health-fill" style="width:100%"></div>

--- a/main.js
+++ b/main.js
@@ -428,11 +428,13 @@ ipcMain.on('open-journey-scene-window', async (event, data) => {
     const win = createJourneySceneWindow();
     if (!win) return;
     const enemy = await getRandomEnemyIdle(currentPet ? currentPet.statusImage : null);
+    const enemyName = enemy ? path.basename(path.dirname(enemy)) : '';
     win.webContents.on('did-finish-load', () => {
         win.webContents.send('scene-data', {
             background: data.background,
             playerPet: currentPet ? (currentPet.statusImage || currentPet.image) : null,
-            enemyPet: enemy
+            enemyPet: enemy,
+            enemyName
         });
     });
 });

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -6,12 +6,17 @@ document.addEventListener('DOMContentLoaded', () => {
     const enemy = document.getElementById('enemy-pet');
     const playerFront = document.getElementById('player-front');
     const enemyFront = document.getElementById('enemy-front');
+    const enemyName = document.getElementById('enemy-name');
 
     window.electronAPI.on('scene-data', (event, data) => {
         if (data.background && bg) bg.src = data.background;
         if (data.playerPet && player) player.src = data.playerPet;
         if (data.enemyPet && enemy) enemy.src = data.enemyPet;
         if (data.playerPet && playerFront) playerFront.src = data.playerPet;
-        if (data.enemyPet && enemyFront) enemyFront.src = data.enemyPet;
+        if (data.enemyPet && enemyFront) {
+            const frontPath = data.enemyPet.replace(/idle\.gif$/i, 'front.gif');
+            enemyFront.src = frontPath;
+        }
+        if (data.enemyName && enemyName) enemyName.textContent = data.enemyName;
     });
 });


### PR DESCRIPTION
## Summary
- scale up health and energy bars for the journey scene
- include `pet-name` styling and show enemy name under its portrait
- always load `front.gif` for enemy HUD image
- send enemy name from the main process

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6851f04401d4832a9432bea643197a30