### PR TITLE
Add visible title bar to journey scene

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -32,6 +32,7 @@
             align-items: center;
             justify-content: space-between;
             padding: 0 5px;
+            z-index: 1; /* Ensure title bar stays above background */
         }
         #title-bar-content {
             display: flex;
@@ -80,6 +81,7 @@
             height: 100%;
             object-fit: cover;
             border-radius: 7px;
+            z-index: 0; /* Keep background behind other elements */
         }
         .pet {
             position: absolute;
@@ -87,6 +89,7 @@
             bottom: 120px;
             width: 150px;
             image-rendering: pixelated;
+            z-index: 1;
         }
         #player-pet { left: 100px; transform: scaleX(-1); }
         #enemy-pet { right: 100px; transform: scaleX(1); }
@@ -96,6 +99,7 @@
             top: 10px;
             display: flex;
             align-items: center;
+            z-index: 1;
         }
         #player-hud { left: 10px; }
         #enemy-hud { right: 10px; flex-direction: row-reverse; }


### PR DESCRIPTION
## Summary
- ensure the journey scene title bar displays above the background
- keep pets and HUD elements visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852067a5018832aa4d7770c06c6da26