### PR TITLE
Enable pet renaming

### DIFF
--- a/main.js
+++ b/main.js
@@ -197,6 +197,26 @@ ipcMain.handle('delete-pet', async (event, petId) => {
     return result;
 });
 
+ipcMain.on('rename-pet', async (event, data) => {
+    if (!currentPet || !data || currentPet.petId !== data.petId) {
+        console.error('Pet para renomear não encontrado');
+        return;
+    }
+    const newName = typeof data.newName === 'string' ? data.newName.trim() : '';
+    if (!newName || newName.length > 15) {
+        console.error('Nome inválido para renomear o pet');
+        return;
+    }
+    try {
+        currentPet = await petManager.updatePet(currentPet.petId, { name: newName });
+        BrowserWindow.getAllWindows().forEach(w => {
+            if (w.webContents) w.webContents.send('pet-data', currentPet);
+        });
+    } catch (err) {
+        console.error('Erro ao renomear pet:', err);
+    }
+});
+
 ipcMain.on('open-status-window', () => {
     console.log('Recebido open-status-window');
     if (currentPet) {

--- a/preload.js
+++ b/preload.js
@@ -20,6 +20,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'store-pet',
             'train-pet',
             'learn-move',
+            'rename-pet',
             'open-battle-mode-window',
             'open-journey-mode-window',
             'open-journey-scene-window',

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -19,6 +19,21 @@ function hideDescription() {
     descriptionEl.style.visibility = 'hidden';
 }
 
+function renamePet() {
+    if (!pet || !pet.petId) return;
+    const newName = prompt('Digite o novo nome do pet:', pet.name);
+    if (!newName) return;
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    if (trimmed.length > 15) {
+        alert('O nome do pet deve ter no m\u00e1ximo 15 caracteres!');
+        return;
+    }
+    pet.name = trimmed;
+    window.electronAPI.send('rename-pet', { petId: pet.petId, newName: trimmed });
+    updateStatus();
+}
+
 function setImageWithFallback(imgElement, relativePath) {
     if (!imgElement) return;
     if (!relativePath) {
@@ -263,6 +278,11 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('DOM carregado na janela de status');
 
     descriptionEl = document.getElementById('move-description');
+
+    const nameSpan = document.getElementById('title-bar-pet-name');
+    const editIcon = document.getElementById('edit-pet-name');
+    if (nameSpan) nameSpan.addEventListener('click', renamePet);
+    if (editIcon) editIcon.addEventListener('click', renamePet);
 
     // Controle das abas
     document.querySelectorAll('.tab-button').forEach(button => {

--- a/status.html
+++ b/status.html
@@ -53,15 +53,31 @@
             margin-right: 5px;
         }
 
+        #title-bar-pet-name-container {
+            display: flex;
+            align-items: center;
+        }
+
         #title-bar-pet-name {
             color: #ffffff;
             font-family: 'PixelOperator', sans-serif;
             font-size: 14px;
-            margin-right: 10px;
+            margin-right: 4px;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
             max-width: 150px;
+            cursor: pointer;
+        }
+
+        #edit-pet-name {
+            display: none;
+            font-size: 12px;
+            cursor: pointer;
+        }
+
+        #title-bar-pet-name-container:hover #edit-pet-name {
+            display: inline;
         }
 
         #close-status-titlebar {
@@ -428,7 +444,10 @@
         <div id="title-bar">
             <div id="title-bar-content">
                 <img id="title-bar-element" src="Assets/Elements/default.png" alt="Elemento" style="image-rendering: pixelated;">
-                <span id="title-bar-pet-name">Nome do Pet</span>
+                <div id="title-bar-pet-name-container">
+                    <span id="title-bar-pet-name">Nome do Pet</span>
+                    <span id="edit-pet-name" title="Editar nome">✏️</span>
+                </div>
             </div>
             <div id="title-bar-buttons">
                 <div id="back-status-titlebar">↩</div>


### PR DESCRIPTION
## Summary
- allow the renderer to send `rename-pet` IPC messages
- handle `rename-pet` in the main process and update windows
- expose the new channel via preload
- add editing UI for the pet name in the status screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6852168cb2ec832a92b81e3247cd04b7