### PR TITLE
Add known moves support

### DIFF
--- a/main.js
+++ b/main.js
@@ -468,6 +468,14 @@ ipcMain.on('resize-journey-window', (event, size) => {
 ipcMain.on('learn-move', async (event, move) => {
     if (!currentPet) return;
     if (!currentPet.moves) currentPet.moves = [];
+    if (!currentPet.knownMoves) currentPet.knownMoves = currentPet.moves.slice();
+    const knownIdx = currentPet.knownMoves.findIndex(m => m.name === move.name);
+    if (knownIdx < 0) {
+        currentPet.knownMoves.push(move);
+    } else {
+        currentPet.knownMoves[knownIdx] = move;
+    }
+
     const idx = currentPet.moves.findIndex(m => m.name === move.name);
     if (idx >= 0) {
         currentPet.moves[idx] = move;
@@ -477,7 +485,7 @@ ipcMain.on('learn-move', async (event, move) => {
         currentPet.moves.push(move);
     }
     try {
-        await petManager.updatePet(currentPet.petId, { moves: currentPet.moves });
+        await petManager.updatePet(currentPet.petId, { moves: currentPet.moves, knownMoves: currentPet.knownMoves });
         BrowserWindow.getAllWindows().forEach(w => {
             if (w.webContents) w.webContents.send('pet-data', currentPet);
         });

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -100,6 +100,7 @@ async function createPet(petData) {
         currentHealth: petData.currentHealth || (petData.attributes?.life || 100),
         maxHealth: petData.maxHealth || (petData.attributes?.life || 100),
         moves: [],
+        knownMoves: [],
         image: petData.image, // A propriedade image será salva aqui
         race: petData.race || null,
         bio: petData.bio || '',
@@ -134,6 +135,9 @@ async function listPets() {
                     const pet = JSON.parse(data);
                     pet.fileName = file; // Garantir que o fileName esteja atualizado
                     ensureStatusImage(pet);
+                    if (!pet.knownMoves) {
+                        pet.knownMoves = pet.moves ? [...pet.moves] : [];
+                    }
                     return pet;
                 } catch (err) {
                     console.error(`Erro ao ler pet do arquivo ${file}:`, err);
@@ -158,6 +162,9 @@ async function loadPet(petId) {
         const data = await fs.readFile(petFilePath, 'utf8');
         const pet = JSON.parse(data);
         ensureStatusImage(pet);
+        if (!pet.knownMoves) {
+            pet.knownMoves = pet.moves ? [...pet.moves] : [];
+        }
         pet.lastAccessed = new Date().toISOString();
         pet.fileName = petFileName; // Garantir que o fileName esteja atualizado
         await fs.writeFile(petFilePath, JSON.stringify(pet, null, 2), 'utf8');

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -65,6 +65,9 @@ function formatRarity(rarity) {
 function loadPet(petData) {
     if (petData) {
         pet = petData;
+        if (!pet.knownMoves) {
+            pet.knownMoves = pet.moves ? [...pet.moves] : [];
+        }
         console.log('Pet recebido via IPC na janela de status:', pet);
     } else {
         console.error('Nenhum petData recebido via IPC');

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -34,6 +34,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
+        if (!pet.knownMoves) {
+            pet.knownMoves = pet.moves ? [...pet.moves] : [];
+        }
         loadMoves();
     });
 });
@@ -68,9 +71,15 @@ function renderMoves(moves) {
         tr.addEventListener('mouseleave', hideDescription);
 
         let action = 'Aprender';
-        const known = pet.moves && pet.moves.some(m => m.name === move.name);
-        if (known) action = 'Reaprender';
-        if (pet.moves && pet.moves.length >= 4 && !known) action = 'Trocar';
+        const active = pet.moves && pet.moves.some(m => m.name === move.name);
+        const learned = pet.knownMoves && pet.knownMoves.some(m => m.name === move.name);
+        if (active) {
+            action = 'Ativo';
+        } else if (learned) {
+            action = 'Ativar';
+        } else if (pet.moves && pet.moves.length >= 4) {
+            action = 'Trocar';
+        }
         if (pet.level < move.level) action = 'Indisponível';
 
         const elementIcons = move.elements.map(el =>
@@ -82,8 +91,11 @@ function renderMoves(moves) {
             case 'Aprender':
                 actionClass = 'action-aprender';
                 break;
-            case 'Reaprender':
-                actionClass = 'action-reaprender';
+            case 'Ativar':
+                actionClass = 'action-ativar';
+                break;
+            case 'Ativo':
+                actionClass = 'action-ativo';
                 break;
             case 'Trocar':
                 actionClass = 'action-trocar';
@@ -105,7 +117,7 @@ function renderMoves(moves) {
         `;
 
         const btn = tr.querySelector('button');
-        if (action === 'Indisponível') {
+        if (action === 'Indisponível' || action === 'Ativo') {
             btn.disabled = true;
         } else {
             btn.addEventListener('click', () => {

--- a/train.html
+++ b/train.html
@@ -78,6 +78,8 @@
         .action-reaprender { background-color:#3498db; }
         .action-trocar { background-color:#f1c40f; }
         .action-indisponivel { background-color:#7f8c8d; }
+        .action-ativar { background-color:#9b59b6; }
+        .action-ativo { background-color:#95a5a6; }
 
         #move-description {
             position: fixed;


### PR DESCRIPTION
## Summary
- track all learned moves via new `knownMoves` property
- show *Ativo* or *Ativar* on training screen with distinct colors
- update move learning logic to maintain `knownMoves`
- ensure status and pet manager handle pets without this property

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685363ab9414832a9328bf480884402c