### PR TITLE
Implement close and music fade on pet creation

### DIFF
--- a/main.js
+++ b/main.js
@@ -91,6 +91,11 @@ ipcMain.on('close-load-pet-window', () => {
     windowManager.closeLoadPetWindow();
 });
 
+ipcMain.on('close-start-window', () => {
+    console.log('Recebido close-start-window');
+    windowManager.closeStartWindow();
+});
+
 ipcMain.on('create-pet', async (event, petData) => {
     console.log('Recebido create-pet com dados:', petData);
     try {
@@ -111,6 +116,11 @@ ipcMain.on('create-pet', async (event, petData) => {
 ipcMain.on('animation-finished', () => {
     console.log('Animação finalizada, prosseguindo com o redirecionamento');
     windowManager.closeCreatePetWindow();
+    const startWin = windowManager.getStartWindow();
+    if (startWin && !startWin.isDestroyed()) {
+        console.log('Solicitando fade-out da música da startWindow');
+        startWin.webContents.send('fade-out-start-music');
+    }
     const trayWindow = windowManager.createTrayWindow();
     trayWindow.webContents.on('did-finish-load', () => {
         console.log('Enviando pet-data para trayWindow:', currentPet);

--- a/preload.js
+++ b/preload.js
@@ -27,7 +27,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'resize-journey-window',
             'set-mute-state',
             'get-journey-images',
-            'animation-finished' // Novo canal pra sinalizar o fim da animação
+            'animation-finished', // Novo canal pra sinalizar o fim da animação
+            'close-start-window'  // Fechar a janela de start
         ];
         if (validChannels.includes(channel)) {
             console.log(`Enviando canal IPC: ${channel}`, data);
@@ -41,7 +42,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'pet-data',
             'show-battle-error',
             'pet-created', // Novo canal pra receber a confirmação do pet criado
-            'scene-data'
+            'scene-data',
+            'fade-out-start-music' // Sinalizar o fade-out da música de start
         ];
         if (validChannels.includes(channel)) {
             console.log(`Registrando listener para o canal: ${channel}`);

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -41,6 +41,24 @@ if (backgroundMusic && muteButton) {
         console.log(`Música ${isMuted ? 'mutada' : 'desmutada'} - Estado enviado via IPC`);
         updateMuteButton();
     });
+
+    function fadeOutAndClose() {
+        let vol = backgroundMusic.volume;
+        const step = vol / 20;
+        const interval = setInterval(() => {
+            vol -= step;
+            if (vol <= 0) {
+                clearInterval(interval);
+                backgroundMusic.volume = 0;
+                backgroundMusic.pause();
+                window.electronAPI.send('close-start-window');
+            } else {
+                backgroundMusic.volume = vol;
+            }
+        }, 100);
+    }
+
+    window.electronAPI.on('fade-out-start-music', fadeOutAndClose);
 } else {
     console.error('Elementos de áudio ou botão de mute não encontrados');
 }


### PR DESCRIPTION
## Summary
- add new IPC channels for closing the start window
- send fade-out request when pet creation finishes
- allow renderer to listen for fade-out event and close the window after fading the music

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685366373fcc832abf627ab1a048489d