### PR TITLE
Adjust training actions

### DIFF
--- a/scripts/train.js
+++ b/scripts/train.js
@@ -68,10 +68,17 @@ function renderMoves(moves) {
         tr.addEventListener('mouseleave', hideDescription);
 
         let action = 'Aprender';
+        let disabled = false;
         const known = pet.moves && pet.moves.some(m => m.name === move.name);
-        if (known) action = 'Reaprender';
-        if (pet.moves && pet.moves.length >= 4 && !known) action = 'Trocar';
-        if (pet.level < move.level) action = 'Indisponível';
+        if (known) {
+            action = 'Ativo';
+            disabled = true;
+        } else if (pet.moves && pet.moves.length >= 4) {
+            action = 'Reaprender';
+        }
+        if (pet.level < move.level) {
+            disabled = true;
+        }
 
         const elementIcons = move.elements.map(el =>
             `<img class="element-icon" src="Assets/Elements/${el}.png" alt="${el}" style="image-rendering: pixelated;">`
@@ -85,11 +92,11 @@ function renderMoves(moves) {
             case 'Reaprender':
                 actionClass = 'action-reaprender';
                 break;
-            case 'Trocar':
-                actionClass = 'action-trocar';
+            case 'Ativo':
+                actionClass = 'action-ativo';
                 break;
             default:
-                actionClass = 'action-indisponivel';
+                actionClass = 'action-aprender';
         }
 
         const rarityStyle = rarityGradients[move.rarity] || rarityGradients['Comum'];
@@ -105,7 +112,7 @@ function renderMoves(moves) {
         `;
 
         const btn = tr.querySelector('button');
-        if (action === 'Indisponível') {
+        if (disabled) {
             btn.disabled = true;
         } else {
             btn.addEventListener('click', () => {

--- a/train.html
+++ b/train.html
@@ -76,8 +76,7 @@
         .element-icon { width:24px; height:24px; }
         .action-aprender { background-color:#2ecc71; }
         .action-reaprender { background-color:#3498db; }
-        .action-trocar { background-color:#f1c40f; }
-        .action-indisponivel { background-color:#7f8c8d; }
+        .action-ativo { background-color:#9b59b6; }
 
         #move-description {
             position: fixed;


### PR DESCRIPTION
## Summary
- show only `Aprender`, `Reaprender` and `Ativo` actions on the training page
- remove old `Trocar` and `Indisponível` options

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6853668a4e78832a9b75e784a352cc69