### PR TITLE
Update train button colors

### DIFF
--- a/train.html
+++ b/train.html
@@ -74,12 +74,13 @@
         .action-button { width:80px; }
         .action-button:disabled { opacity:0.5; cursor:default; }
         .element-icon { width:24px; height:24px; }
-        .action-aprender { background-color:#2ecc71; }
-        .action-reaprender { background-color:#3498db; }
+        /* Ajuste de cores dos botões na janela de treino */
+        .action-aprender { background-color:#3498db; }
+        .action-reaprender { background-color:#95a5a6; }
         .action-trocar { background-color:#f1c40f; }
         .action-indisponivel { background-color:#7f8c8d; }
         .action-ativar { background-color:#9b59b6; }
-        .action-ativo { background-color:#95a5a6; }
+        .action-ativo { background-color:#2ecc71; }
 
         #move-description {
             position: fixed;


### PR DESCRIPTION
## Summary
- set colors for "Aprender", "Reaprender" and "Ativo" buttons in **train.html**

## Testing
- `none`

------
https://chatgpt.com/codex/tasks/task_e_68537b752ca4832aadf6da5270f35de3