### PR TITLE
Add basic status effect data and icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ backups/
 # Git
 .git
 pets/
+Assets/icons/*.png

--- a/README.md
+++ b/README.md
@@ -37,3 +37,16 @@ pet.
 - `npm install` – instalação das dependências.
 - `npm start` – inicia a aplicação.
 
+
+## Efeitos de Status
+
+Alguns golpes podem aplicar condições especiais durante as batalhas. Os efeitos disponíveis são:
+
+- **Queimadura**: dano de 2% a 3% da vida total por turno durante 2 a 3 turnos.
+- **Envenenamento**: dano de 1% a 2% da vida total por turno durante 3 a 5 turnos.
+- **Sangramento**: dano de 3% da vida atual por turno por 2 turnos.
+- **Dormência**: impede o pet de agir por 1 a 3 turnos; receber dano desperta o pet.
+- **Congelamento**: paralisa o pet por 1 a 3 turnos e só é removido por cura ou calor.
+- **Paralisia**: 50% de chance de não agir por 1 a 2 turnos, reduzindo um pouco a velocidade.
+
+Os ícones desses efeitos estão em `Assets/icons`.

--- a/data/status-effects.json
+++ b/data/status-effects.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "burn",
+    "name": "Queimadura",
+    "icon": "Assets/icons/burning.png",
+    "duration": "2-3",
+    "damage": "-2% a -3% da vida total por turno",
+    "extra": "Pode impedir regeneração durante o efeito"
+  },
+  {
+    "id": "poison",
+    "name": "Envenenamento",
+    "icon": "Assets/icons/poison.png",
+    "duration": "3-5",
+    "damage": "-1% a -2% da vida total por turno",
+    "extra": "Acumula com outros efeitos de dano, como sangramento"
+  },
+  {
+    "id": "bleed",
+    "name": "Sangramento",
+    "icon": "Assets/icons/bleed.png",
+    "duration": "2",
+    "damage": "-3% da vida atual por turno",
+    "extra": "Pode aumentar com ataques físicos recebidos"
+  },
+  {
+    "id": "sleep",
+    "name": "Dormência",
+    "icon": "Assets/icons/sleep.png",
+    "duration": "1-3",
+    "damage": null,
+    "extra": "Qualquer dano recebido acorda o pet no próximo turno"
+  },
+  {
+    "id": "freeze",
+    "name": "Congelamento",
+    "icon": "Assets/icons/freeze.png",
+    "duration": "1-3",
+    "damage": null,
+    "extra": "Não acorda com dano, mas pode ser removido com habilidades de cura ou calor"
+  },
+  {
+    "id": "paralyze",
+    "name": "Paralisia",
+    "icon": "Assets/icons/paralyze.png",
+    "duration": "1-2",
+    "damage": null,
+    "extra": "50% de chance de não agir e reduz a velocidade"
+  }
+]

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -1,4 +1,13 @@
 import { rarityGradients } from './constants.js';
+
+const statusIcons = {
+    'queimado': 'Assets/icons/burning.png',
+    'envenenamento': 'Assets/icons/poison.png',
+    'sangramento': 'Assets/icons/bleed.png',
+    'dormencia': 'Assets/icons/sleep.png',
+    'congelamento': 'Assets/icons/freeze.png',
+    'paralisia': 'Assets/icons/paralyze.png'
+};
 console.log('train.js carregado');
 
 let pet = null;
@@ -105,12 +114,15 @@ function renderMoves(moves) {
         }
 
         const rarityStyle = rarityGradients[move.rarity] || rarityGradients['Comum'];
+        const effectIcon = statusIcons[move.effect?.toLowerCase()];
+        const effectHtml = effectIcon ? `<img class="status-icon" src="${effectIcon}" alt="${move.effect}">` : move.effect;
+
         tr.innerHTML = `
             <td>${move.name}</td>
             <td><span style="padding: 5px; background: ${rarityStyle}; border-radius: 5px;">${move.rarity}</span></td>
             <td>${elementIcons}</td>
             <td>${move.power}</td>
-            <td>${move.effect}</td>
+            <td>${effectHtml}</td>
             <td>${move.cost}</td>
             <td>${move.level}</td>
             <td><button class="button small-button action-button ${actionClass}">${action}</button></td>

--- a/train.html
+++ b/train.html
@@ -74,6 +74,7 @@
         .action-button { width:80px; }
         .action-button:disabled { opacity:0.5; cursor:default; }
         .element-icon { width:24px; height:24px; }
+        .status-icon { width:24px; height:24px; image-rendering: pixelated; }
         /* Ajuste de cores dos botões na janela de treino */
         .action-aprender { background-color:#3498db; }
         .action-reaprender { background-color:#95a5a6; }


### PR DESCRIPTION
## Summary
- include icons for burn, poison and other status effects
- list the new effects in the README
- show icons in the training screen when listing moves
- store status effect data in `data/status-effects.json`
- ignore icon binaries in git

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685414fa95f4832ab082203dee6ca346