### PR TITLE
Implement health-aware move scaling

### DIFF
--- a/scripts/moveEffectiveness.js
+++ b/scripts/moveEffectiveness.js
@@ -1,0 +1,16 @@
+export function calculateMovePower(basePower, level, maxHealth) {
+  if (!basePower || basePower <= 0) return 0;
+
+  const effectiveLevel = Math.max(level, 1);
+  const levelScale = 1 + (effectiveLevel - 1) * 0.05; // 5% increase per level
+
+  let scaled = basePower * levelScale;
+
+  if (typeof maxHealth === 'number' && maxHealth > 0) {
+    const min = Math.ceil(maxHealth * 0.05); // at least 5% of max health
+    const max = Math.ceil(maxHealth * 0.3); // at most 30% of max health
+    scaled = Math.min(Math.max(scaled, min), max);
+  }
+
+  return Math.round(scaled);
+}

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -1,4 +1,5 @@
 import { rarityGradients } from './constants.js';
+import { calculateMovePower } from './moveEffectiveness.js';
 
 const statusIcons = {
     'queimado': 'Assets/icons/burning.png',
@@ -121,7 +122,7 @@ function renderMoves(moves) {
             <td>${move.name}</td>
             <td><span style="padding: 5px; background: ${rarityStyle}; border-radius: 5px;">${move.rarity}</span></td>
             <td>${elementIcons}</td>
-            <td>${move.power}</td>
+            <td>${calculateMovePower(move.power, pet.level, pet.maxHealth)}</td>
             <td>${effectHtml}</td>
             <td>${move.cost}</td>
             <td>${move.level}</td>


### PR DESCRIPTION
## Summary
- add maxHealth parameter to move power calculation
- clamp scaled move power between 5% and 30% of max health
- show health-adjusted power in training screen

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685424cc6a24832a82feef1c116cc792