### PR TITLE
Show kadir points

### DIFF
--- a/main.js
+++ b/main.js
@@ -295,6 +295,7 @@ ipcMain.on('battle-pet', async () => {
         while (currentPet.experience >= requiredXp && currentPet.level < 100) {
             currentPet.level += 1;
             currentPet.experience -= requiredXp;
+            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 1;
             increaseAttributesOnLevelUp(currentPet);
             console.log(`Pet subiu para o nível ${currentPet.level}! XP restante: ${currentPet.experience}`);
             requiredXp = getRequiredXpForNextLevel(currentPet.level);
@@ -307,7 +308,8 @@ ipcMain.on('battle-pet', async () => {
                 attributes: currentPet.attributes,
                 maxHealth: currentPet.maxHealth,
                 currentHealth: currentPet.currentHealth,
-                energy: currentPet.energy
+                energy: currentPet.energy,
+                kadirPoints: currentPet.kadirPoints
             });
         } catch (err) {
             console.error('Erro ao atualizar pet após batalha:', err);

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -268,7 +268,8 @@ function showNameSelection(element) {
             happiness: 100,
             currentHealth: stats.life,
             maxHealth: stats.life,
-            energy: 100
+            energy: 100,
+            kadirPoints: 5
         };
 
         console.log('Pet a ser criado:', petData);

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -97,6 +97,7 @@ async function createPet(petData) {
         hunger: petData.hunger || 100,
         happiness: petData.happiness || 100,
         energy: petData.energy || 100,
+        kadirPoints: petData.kadirPoints || 5,
         currentHealth: petData.currentHealth || (petData.attributes?.life || 100),
         maxHealth: petData.maxHealth || (petData.attributes?.life || 100),
         moves: [],
@@ -133,6 +134,9 @@ async function listPets() {
                 try {
                     const data = await fs.readFile(filePath, 'utf8');
                     const pet = JSON.parse(data);
+                    if (pet.kadirPoints === undefined) {
+                        pet.kadirPoints = 5;
+                    }
                     pet.fileName = file; // Garantir que o fileName esteja atualizado
                     ensureStatusImage(pet);
                     if (!pet.knownMoves) {
@@ -161,6 +165,9 @@ async function loadPet(petId) {
     try {
         const data = await fs.readFile(petFilePath, 'utf8');
         const pet = JSON.parse(data);
+        if (pet.kadirPoints === undefined) {
+            pet.kadirPoints = 5;
+        }
         ensureStatusImage(pet);
         if (!pet.knownMoves) {
             pet.knownMoves = pet.moves ? [...pet.moves] : [];

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -91,6 +91,7 @@ function updateStatus() {
     const statusHappinessFill = document.getElementById('status-happiness-fill');
     const statusEnergyFill = document.getElementById('status-energy-fill');
     const statusLevel = document.getElementById('status-level');
+    const statusKadirPoints = document.getElementById('kadir-points-value');
     const statusMoves = document.getElementById('status-moves');
     const statusPetImage = document.getElementById('status-pet-image');
     const statusBioImage = document.getElementById('status-bio-image');
@@ -100,7 +101,7 @@ function updateStatus() {
     const statusPetImageGradient = document.getElementById('status-pet-image-gradient');
 
     // Verificar se todos os elementos estão disponíveis
-    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText) {
+    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusKadirPoints || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText) {
         console.error('Um ou mais elementos do status-container ou title-bar não encontrados', {
             healthContainer: !!healthContainer,
             hungerContainer: !!hungerContainer,
@@ -117,6 +118,7 @@ function updateStatus() {
             statusEnergyFill: !!statusEnergyFill,
             statusLevel: !!statusLevel,
             statusMoves: !!statusMoves,
+            statusKadirPoints: !!statusKadirPoints,
             statusPetImage: !!statusPetImage,
             statusBioImage: !!statusBioImage,
             titleBarElement: !!titleBarElement,
@@ -149,6 +151,7 @@ function updateStatus() {
     statusMagic.textContent = pet.attributes?.magic || 0;
     statusRarityLabel.textContent = formatRarity(pet.rarity).toUpperCase();
     statusLevel.innerHTML = `<strong>Level: ${pet.level || 0}</strong>`;
+    statusKadirPoints.textContent = pet.kadirPoints ?? 0;
 
     // Atualizar a imagem do elemento na barra de título
     const elementImages = {

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -47,6 +47,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!pet.knownMoves) {
             pet.knownMoves = pet.moves ? [...pet.moves] : [];
         }
+        const kpEl = document.getElementById('train-kadir-points-value');
+        if (kpEl) kpEl.textContent = pet.kadirPoints ?? 0;
         loadMoves();
     });
 });
@@ -124,7 +126,7 @@ function renderMoves(moves) {
             <td>${elementIcons}</td>
             <td>${calculateMovePower(move.power, pet.level, pet.maxHealth)}</td>
             <td>${effectHtml}</td>
-            <td>${move.cost}</td>
+            <td><img src="assets/icons/dna-kadir.png" alt="KP" style="height:16px; vertical-align:middle; image-rendering:pixelated;"> ${move.cost}</td>
             <td>${move.level}</td>
             <td><button class="button small-button action-button ${actionClass}">${action}</button></td>
         `;

--- a/status.html
+++ b/status.html
@@ -220,6 +220,18 @@
             z-index: 4;
         }
 
+        #status-kadir-points {
+            position: absolute;
+            bottom: 5px;
+            left: 80px;
+            font-size: 14px;
+            color: #ffffff;
+            background-color: rgba(0, 0, 0, 0.5);
+            padding: 2px 5px;
+            border-radius: 3px;
+            z-index: 4;
+        }
+
         .status-bar {
             width: 100%;
             height: 10px;
@@ -464,6 +476,7 @@
                         <img id="status-bio-image" src="" alt="Bio do Pet" style="image-rendering: pixelated;">
                         <div id="status-rarity-label">RARIDADE</div>
                         <div id="status-level">Level: 0</div>
+                        <div id="status-kadir-points"><img src="assets/icons/dna-kadir.png" alt="KP" style="height: 16px; vertical-align: middle; image-rendering: pixelated;"> <span id="kadir-points-value">0</span></div>
                     </div>
                 </div>
                 <div class="tab-buttons">

--- a/train.html
+++ b/train.html
@@ -107,6 +107,9 @@
             </div>
         </div>
         <div id="train-container">
+            <div id="train-kadir-points" style="text-align:right; padding:4px;">
+                <img src="assets/icons/dna-kadir.png" alt="KP" style="height:16px; vertical-align:middle; image-rendering: pixelated;"> <span id="train-kadir-points-value">0</span>
+            </div>
             <table id="moves-table">
                 <thead>
                     <tr>


### PR DESCRIPTION
## Summary
- add `kadirPoints` attribute when creating a pet
- store and load kadir points for pets
- gain 1 kadir point per level
- show kadir points on status and train pages
- display kadir point icon next to move costs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685445982028832aaa2328abd9f10731