### PR TITLE
Apply reduced cost on relearning moves

### DIFF
--- a/main.js
+++ b/main.js
@@ -505,6 +505,19 @@ ipcMain.on('learn-move', async (event, move) => {
     if (!currentPet) return;
     if (!currentPet.moves) currentPet.moves = [];
     if (!currentPet.knownMoves) currentPet.knownMoves = currentPet.moves.slice();
+
+    const learnedBefore = currentPet.knownMoves.some(m => m.name === move.name);
+    const cost = learnedBefore ? Math.ceil(move.cost / 2) : move.cost;
+
+    if ((currentPet.kadirPoints || 0) < cost) {
+        BrowserWindow.getAllWindows().forEach(w => {
+            if (w.webContents) w.webContents.send('show-train-error', 'Pontos Kadir insuficientes!');
+        });
+        return;
+    }
+
+    currentPet.kadirPoints = (currentPet.kadirPoints || 0) - cost;
+
     const knownIdx = currentPet.knownMoves.findIndex(m => m.name === move.name);
     if (knownIdx < 0) {
         currentPet.knownMoves.push(move);
@@ -521,7 +534,7 @@ ipcMain.on('learn-move', async (event, move) => {
         currentPet.moves.push(move);
     }
     try {
-        await petManager.updatePet(currentPet.petId, { moves: currentPet.moves, knownMoves: currentPet.knownMoves });
+        await petManager.updatePet(currentPet.petId, { moves: currentPet.moves, knownMoves: currentPet.knownMoves, kadirPoints: currentPet.kadirPoints });
         BrowserWindow.getAllWindows().forEach(w => {
             if (w.webContents) w.webContents.send('pet-data', currentPet);
         });

--- a/preload.js
+++ b/preload.js
@@ -41,6 +41,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
         const validChannels = [
             'pet-data',
             'show-battle-error',
+            'show-train-error',
             'pet-created', // Novo canal pra receber a confirmação do pet criado
             'scene-data',
             'fade-out-start-music' // Sinalizar o fade-out da música de start

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -14,6 +14,7 @@ console.log('train.js carregado');
 let pet = null;
 
 let descriptionEl = null;
+let trainAlert = null;
 
 function showDescription(text, evt) {
     if (!descriptionEl) return;
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     descriptionEl = document.getElementById('move-description');
+    trainAlert = document.getElementById('train-alert');
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
@@ -50,6 +52,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const kpEl = document.getElementById('train-kadir-points-value');
         if (kpEl) kpEl.textContent = pet.kadirPoints ?? 0;
         loadMoves();
+    });
+
+    window.electronAPI.on('show-train-error', (event, message) => {
+        if (trainAlert) {
+            trainAlert.textContent = message || 'Erro desconhecido';
+            trainAlert.style.display = 'block';
+            setTimeout(() => {
+                trainAlert.style.display = 'none';
+            }, 3000);
+        } else {
+            alert(message);
+        }
     });
 });
 
@@ -120,13 +134,18 @@ function renderMoves(moves) {
         const effectIcon = statusIcons[move.effect?.toLowerCase()];
         const effectHtml = effectIcon ? `<img class="status-icon" src="${effectIcon}" alt="${move.effect}">` : move.effect;
 
+        let displayCost = move.cost;
+        if (learned) {
+            displayCost = Math.ceil(move.cost / 2);
+        }
+
         tr.innerHTML = `
             <td>${move.name}</td>
             <td><span style="padding: 5px; background: ${rarityStyle}; border-radius: 5px;">${move.rarity}</span></td>
             <td>${elementIcons}</td>
             <td>${calculateMovePower(move.power, pet.level, pet.maxHealth)}</td>
             <td>${effectHtml}</td>
-            <td><img src="assets/icons/dna-kadir.png" alt="KP" style="height:16px; vertical-align:middle; image-rendering:pixelated;"> ${move.cost}</td>
+            <td><img src="assets/icons/dna-kadir.png" alt="KP" style="height:16px; vertical-align:middle; image-rendering:pixelated;"> ${displayCost}</td>
             <td>${move.level}</td>
             <td><button class="button small-button action-button ${actionClass}">${action}</button></td>
         `;

--- a/train.html
+++ b/train.html
@@ -83,6 +83,25 @@
         .action-ativar { background-color:#9b59b6; }
         .action-ativo { background-color:#2ecc71; }
 
+        /* Alerta de treino no meio da tela */
+        #train-alert {
+            display: none;
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background-color: rgba(0, 0, 0, 0.8);
+            color: white;
+            padding: 10px 20px;
+            border-radius: 5px;
+            z-index: 20;
+            font-family: 'PixelOperator', sans-serif;
+            font-size: 14px;
+            text-align: center;
+            max-width: 200px;
+            line-height: 1.2;
+        }
+
         #move-description {
             position: fixed;
             pointer-events: none;
@@ -127,6 +146,7 @@
             </table>
             <div id="move-description"></div>
         </div>
+        <div id="train-alert"></div>
     </div>
     <script type="module" src="scripts/train.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show a training alert overlay in `train.html`
- display KP cost with discount when move already known
- notify training errors with `show-train-error`
- deduct Kadir points when learning moves with discount logic
- expose new IPC channel `show-train-error`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68544a7d79c4832abb03ab9a70fb24fb