### PR TITLE
Ensure windows close when switching pets

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,6 +78,7 @@ ipcMain.on('open-create-pet-window', () => {
 
 ipcMain.on('open-load-pet-window', () => {
     console.log('Recebido open-load-pet-window');
+    closeAllGameWindows();
     windowManager.createLoadPetWindow();
 });
 
@@ -162,6 +163,9 @@ ipcMain.on('select-pet', async (event, petId) => {
         } else {
             console.log('Nenhuma startWindow encontrada para fechar ou já está destruída');
         }
+
+        // Garantir que todas as janelas extras estejam fechadas
+        closeAllGameWindows();
 
         // Verificar se já existe uma trayWindow aberta
         const allWindows = BrowserWindow.getAllWindows();
@@ -462,6 +466,41 @@ function createTrainWindow() {
     });
 
     return trainWindow;
+}
+
+function closeBattleModeWindow() {
+    if (battleModeWindow) {
+        battleModeWindow.close();
+    }
+}
+
+function closeJourneyModeWindow() {
+    if (journeyModeWindow) {
+        journeyModeWindow.close();
+    }
+}
+
+function closeJourneySceneWindow() {
+    if (journeySceneWindow) {
+        journeySceneWindow.close();
+    }
+}
+
+function closeTrainWindow() {
+    if (trainWindow) {
+        trainWindow.close();
+    }
+}
+
+function closeAllGameWindows() {
+    windowManager.closeTrayWindow();
+    windowManager.closeStatusWindow();
+    windowManager.closeCreatePetWindow();
+    windowManager.closeStartWindow();
+    closeBattleModeWindow();
+    closeJourneyModeWindow();
+    closeJourneySceneWindow();
+    closeTrainWindow();
 }
 
 ipcMain.on('open-battle-mode-window', () => {

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -234,6 +234,13 @@ class WindowManager {
         return this.trayWindow;
     }
 
+    // Fechar a trayWindow
+    closeTrayWindow() {
+        if (this.trayWindow) {
+            this.trayWindow.close();
+        }
+    }
+
     // Criar a janela de status (status.html)
     createStatusWindow() {
         if (this.statusWindow) {
@@ -263,6 +270,13 @@ class WindowManager {
         });
 
         return this.statusWindow;
+    }
+
+    // Fechar a statusWindow
+    closeStatusWindow() {
+        if (this.statusWindow) {
+            this.statusWindow.close();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add close methods for tray and status windows
- create helpers in `main.js` to close any open windows
- close all windows before opening the load pet window
- close remaining windows when selecting a pet

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685448cdd524832a97fcd91bfbd68f84