### PR TITLE
Fix back navigation from pet selection

### DIFF
--- a/main.js
+++ b/main.js
@@ -78,7 +78,8 @@ ipcMain.on('open-create-pet-window', () => {
 
 ipcMain.on('open-load-pet-window', () => {
     console.log('Recebido open-load-pet-window');
-    closeAllGameWindows();
+    // Não fechar todas as janelas para permitir voltar
+    // à tela anterior (start ou index) ao sair da seleção
     windowManager.createLoadPetWindow();
 });
 


### PR DESCRIPTION
## Summary
- allow returning to previous screen when leaving `load-pet.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68544d46592c832ab3aa396d3e75303f