### PR TITLE
Show currency when selecting pets

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -104,6 +104,12 @@
             margin: 5px 0;
         }
 
+        .currency-icon {
+            height: 16px;
+            vertical-align: middle;
+            image-rendering: pixelated;
+            margin-right: 2px;
+        }
         .delete-button {
             background-color: #ff4444;
             border: none;
@@ -216,6 +222,8 @@
                             <p><strong>Nível:</strong> ${pet.level}</p>
                             <p><strong>Raridade:</strong> ${formatRarity(pet.rarity)}</p>
                             <p><strong>Último Acesso:</strong> ${pet.lastAccessed ? formatDate(pet.lastAccessed) : 'Nunca'}</p>
+                            <p><img class="currency-icon" src="assets/icons/dna-kadir.png" alt="KP"> ${pet.kadirPoints ?? 0}</p>
+                            <p><img class="currency-icon" src="assets/icons/kadircoin.png" alt="Moedas"> ${pet.coins ?? 0}</p>
                         </div>
                         <button class="delete-button" data-pet-id="${pet.petId}">
                             <img src="Assets/Icons/trash-can.svg" alt="Delete Icon" style="image-rendering: pixelated;" />


### PR DESCRIPTION
## Summary
- display number of Kadir Points and coins for each pet when selecting
- add CSS for currency icons

## Testing
- `npm test` *(fails: no test specified)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68545d6fb658832aa5203163415ceeb3