### PR TITLE
Update items UI with tooltip and store button position

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "healthPotion",
+    "name": "Poção de Vida",
+    "icon": "Assets/Shop/health-potion.png",
+    "description": "Recupera 20 pontos de saúde."
+  },
+  {
+    "id": "meat",
+    "name": "Carne",
+    "icon": "Assets/Shop/meat1.png",
+    "description": "Sacia 20 pontos de fome."
+  },
+  {
+    "id": "staminaPotion",
+    "name": "Poção de Energia",
+    "icon": "Assets/Shop/stamina-potion.png",
+    "description": "Recupera 20 pontos de energia."
+  }
+]

--- a/items.html
+++ b/items.html
@@ -102,8 +102,23 @@
             text-align: center;
         }
         #open-store-button {
-            align-self: center;
-            margin-top: 5px;
+            position: absolute;
+            top: 35px;
+            right: 5px;
+            align-self: unset;
+        }
+
+        #item-description {
+            position: fixed;
+            pointer-events: none;
+            visibility: hidden;
+            padding: 4px 8px;
+            background: #2a323e;
+            color: #fff;
+            font-size: 14px;
+            border-radius: 4px;
+            z-index: 1000;
+            white-space: nowrap;
         }
     </style>
 </head>
@@ -120,24 +135,9 @@
             <img id="coin-icon" src="assets/icons/kadircoin.png" alt="Moedas" />
             <span id="coin-count">0</span>
         </div>
-        <div id="items-list">
-            <div class="inventory-item">
-                <img src="Assets/Shop/health-potion.png" alt="Health Potion">
-                <span class="item-qty" id="qty-healthPotion">0</span>
-                <button class="button small-button use-button" data-item="healthPotion">Usar</button>
-            </div>
-            <div class="inventory-item">
-                <img src="Assets/Shop/meat1.png" alt="Meat">
-                <span class="item-qty" id="qty-meat">0</span>
-                <button class="button small-button use-button" data-item="meat">Usar</button>
-            </div>
-            <div class="inventory-item">
-                <img src="Assets/Shop/stamina-potion.png" alt="Stamina Potion">
-                <span class="item-qty" id="qty-staminaPotion">0</span>
-                <button class="button small-button use-button" data-item="staminaPotion">Usar</button>
-            </div>
-        </div>
+        <div id="items-list"></div>
         <button class="button small-button" id="open-store-button">Loja</button>
+        <div id="item-description"></div>
     </div>
     <script type="module" src="scripts/items.js"></script>
 </body>

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -1,4 +1,20 @@
 let pet = null;
+let itemsInfo = {};
+let descriptionEl = null;
+
+function showDescription(text, evt) {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = text;
+    descriptionEl.style.left = `${evt.pageX + 10}px`;
+    descriptionEl.style.top = `${evt.pageY + 10}px`;
+    descriptionEl.style.visibility = 'visible';
+}
+
+function hideDescription() {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = '';
+    descriptionEl.style.visibility = 'hidden';
+}
 
 function closeWindow() {
     window.close();
@@ -14,12 +30,8 @@ document.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.send('store-pet');
     });
 
-    document.querySelectorAll('.use-button').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const item = btn.dataset.item;
-            window.electronAPI.send('use-item', item);
-        });
-    });
+    descriptionEl = document.getElementById('item-description');
+    loadItemsInfo();
 
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
@@ -29,16 +41,54 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+async function loadItemsInfo() {
+    try {
+        const response = await fetch('data/items.json');
+        const data = await response.json();
+        itemsInfo = {};
+        data.forEach(it => { itemsInfo[it.id] = it; });
+        updateItems();
+    } catch (err) {
+        console.error('Erro ao carregar itens:', err);
+    }
+}
+
 function updateItems() {
-    if (!pet) return;
+    if (!pet || !Object.keys(itemsInfo).length) return;
     const items = pet.items || {};
-    const map = {
-        healthPotion: 'qty-healthPotion',
-        meat: 'qty-meat',
-        staminaPotion: 'qty-staminaPotion'
-    };
-    Object.keys(map).forEach(key => {
-        const el = document.getElementById(map[key]);
-        if (el) el.textContent = items[key] ?? 0;
+    const listEl = document.getElementById('items-list');
+    if (!listEl) return;
+    listEl.innerHTML = '';
+    Object.keys(items).forEach(id => {
+        const qty = items[id];
+        const info = itemsInfo[id];
+        if (!info || qty <= 0) return;
+
+        const div = document.createElement('div');
+        div.className = 'inventory-item';
+        div.addEventListener('mouseenter', (e) => showDescription(info.description || '', e));
+        div.addEventListener('mousemove', (e) => {
+            if (descriptionEl && descriptionEl.style.visibility === 'visible') {
+                descriptionEl.style.left = `${e.pageX + 10}px`;
+                descriptionEl.style.top = `${e.pageY + 10}px`;
+            }
+        });
+        div.addEventListener('mouseleave', hideDescription);
+        div.addEventListener('click', () => {
+            window.electronAPI.send('use-item', id);
+        });
+
+        const img = document.createElement('img');
+        img.src = info.icon;
+        img.alt = info.name;
+        img.style.imageRendering = 'pixelated';
+
+        const span = document.createElement('span');
+        span.className = 'item-qty';
+        span.textContent = qty;
+
+        div.appendChild(img);
+        div.appendChild(span);
+        listEl.appendChild(div);
     });
 }


### PR DESCRIPTION
## Summary
- reposition store button to top-right corner
- show only owned items and display description on hover
- load item info from new `data/items.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68555e051820832aa481babbf9c26403