### PR TITLE
Add item description tooltip in store

### DIFF
--- a/scripts/store.js
+++ b/scripts/store.js
@@ -1,4 +1,20 @@
 let pet = null;
+let itemsInfo = {};
+let descriptionEl = null;
+
+function showDescription(text, evt) {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = text;
+    descriptionEl.style.left = `${evt.pageX + 10}px`;
+    descriptionEl.style.top = `${evt.pageY + 10}px`;
+    descriptionEl.style.visibility = 'visible';
+}
+
+function hideDescription() {
+    if (!descriptionEl) return;
+    descriptionEl.textContent = '';
+    descriptionEl.style.visibility = 'hidden';
+}
 
 function closeWindow() {
     window.close();
@@ -10,6 +26,9 @@ document.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.send('open-status-window');
         closeWindow();
     });
+
+    descriptionEl = document.getElementById('store-item-description');
+    loadItemsInfo();
 
     document.querySelectorAll('.buy-button').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -35,3 +54,32 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 });
+
+async function loadItemsInfo() {
+    try {
+        const response = await fetch('data/items.json');
+        const data = await response.json();
+        itemsInfo = {};
+        data.forEach(it => { itemsInfo[it.id] = it; });
+        setupHover();
+    } catch (err) {
+        console.error('Erro ao carregar itens da loja:', err);
+    }
+}
+
+function setupHover() {
+    const items = document.querySelectorAll('.store-item');
+    items.forEach(div => {
+        const id = div.dataset.item;
+        if (!id || !itemsInfo[id]) return;
+        const text = `${itemsInfo[id].name} - ${itemsInfo[id].description}`;
+        div.addEventListener('mouseenter', (e) => showDescription(text, e));
+        div.addEventListener('mousemove', (e) => {
+            if (descriptionEl && descriptionEl.style.visibility === 'visible') {
+                descriptionEl.style.left = `${e.pageX + 10}px`;
+                descriptionEl.style.top = `${e.pageY + 10}px`;
+            }
+        });
+        div.addEventListener('mouseleave', hideDescription);
+    });
+}

--- a/store.html
+++ b/store.html
@@ -91,6 +91,18 @@
         .store-item { display:flex; flex-direction:column; align-items:center; }
         .store-item img { width:32px; height:32px; image-rendering:pixelated; }
         .item-price { margin:4px 0; }
+        #store-item-description {
+            position: fixed;
+            pointer-events: none;
+            visibility: hidden;
+            padding: 4px 8px;
+            background: #2a323e;
+            color: #fff;
+            font-size: 14px;
+            border-radius: 4px;
+            z-index: 1000;
+            white-space: nowrap;
+        }
         #store-alert {
             display:none;
             position:absolute;
@@ -120,23 +132,24 @@
             <span id="store-coin-count">0</span>
         </div>
         <div id="store-items">
-            <div class="store-item">
+            <div class="store-item" data-item="healthPotion">
                 <img src="Assets/Shop/health-potion.png" alt="Health Potion">
                 <div class="item-price">10 moedas</div>
                 <button class="button small-button buy-button" data-item="healthPotion">Comprar</button>
             </div>
-            <div class="store-item">
+            <div class="store-item" data-item="meat">
                 <img src="Assets/Shop/meat1.png" alt="Meat">
                 <div class="item-price">5 moedas</div>
                 <button class="button small-button buy-button" data-item="meat">Comprar</button>
             </div>
-            <div class="store-item">
+            <div class="store-item" data-item="staminaPotion">
                 <img src="Assets/Shop/stamina-potion.png" alt="Stamina Potion">
                 <div class="item-price">8 moedas</div>
                 <button class="button small-button buy-button" data-item="staminaPotion">Comprar</button>
             </div>
         </div>
         <div id="store-alert"></div>
+        <div id="store-item-description"></div>
     </div>
     <script type="module" src="scripts/store.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- show tooltip when hovering store items
- fetch item information from `data/items.json`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68555fcfb688832a9f8e8f1cdd26f70d