### PR TITLE
Enhance items list display

### DIFF
--- a/items.html
+++ b/items.html
@@ -91,15 +91,25 @@
             display: flex;
             align-items: center;
             gap: 5px;
+            padding: 5px 0;
+            border-bottom: 1px solid #2a323e;
+        }
+        .inventory-item:last-child {
+            border-bottom: none;
         }
         .inventory-item img {
             width: 32px;
             height: 32px;
             image-rendering: pixelated;
         }
+        .item-name {
+            flex-grow: 1;
+        }
         .item-qty {
-            width: 20px;
-            text-align: center;
+            margin-right: 4px;
+        }
+        .use-button {
+            width: 60px;
         }
         #open-store-button {
             position: absolute;

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -74,21 +74,32 @@ function updateItems() {
             }
         });
         div.addEventListener('mouseleave', hideDescription);
-        div.addEventListener('click', () => {
-            window.electronAPI.send('use-item', id);
-        });
 
         const img = document.createElement('img');
         img.src = info.icon;
         img.alt = info.name;
         img.style.imageRendering = 'pixelated';
 
-        const span = document.createElement('span');
-        span.className = 'item-qty';
-        span.textContent = qty;
+        const nameSpan = document.createElement('span');
+        nameSpan.className = 'item-name';
+        nameSpan.textContent = info.name;
+
+        const qtySpan = document.createElement('span');
+        qtySpan.className = 'item-qty';
+        qtySpan.textContent = `x ${qty}`;
+
+        const useBtn = document.createElement('button');
+        useBtn.className = 'button small-button use-button';
+        useBtn.textContent = 'Usar';
+        useBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            window.electronAPI.send('use-item', id);
+        });
 
         div.appendChild(img);
-        div.appendChild(span);
+        div.appendChild(nameSpan);
+        div.appendChild(qtySpan);
+        div.appendChild(useBtn);
         listEl.appendChild(div);
     });
 }


### PR DESCRIPTION
## Summary
- format items list layout with dividers and spacing
- show item names, quantities and use button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855610a2300832a903fc151c70c8623