### PR TITLE
Add hover tooltip to store items

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -2,19 +2,22 @@
   {
     "id": "healthPotion",
     "name": "Poção de Vida",
-    "icon": "Assets/Shop/health-potion.png",
-    "description": "Recupera 20 pontos de saúde."
+  "icon": "Assets/Shop/health-potion.png",
+  "description": "Recupera 20 pontos de saúde.",
+  "effect": "Recupera 20 pontos de saúde."
   },
   {
     "id": "meat",
     "name": "Carne",
     "icon": "Assets/Shop/meat1.png",
-    "description": "Sacia 20 pontos de fome."
+    "description": "Sacia 20 pontos de fome.",
+    "effect": "Sacia 20 pontos de fome."
   },
   {
     "id": "staminaPotion",
     "name": "Poção de Energia",
     "icon": "Assets/Shop/stamina-potion.png",
-    "description": "Recupera 20 pontos de energia."
+    "description": "Recupera 20 pontos de energia.",
+    "effect": "Recupera 20 pontos de energia."
   }
 ]

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -2,9 +2,9 @@ let pet = null;
 let itemsInfo = {};
 let descriptionEl = null;
 
-function showDescription(text, evt) {
+function showDescription(html, evt) {
     if (!descriptionEl) return;
-    descriptionEl.textContent = text;
+    descriptionEl.innerHTML = html;
     descriptionEl.style.left = `${evt.pageX + 10}px`;
     descriptionEl.style.top = `${evt.pageY + 10}px`;
     descriptionEl.style.visibility = 'visible';
@@ -12,7 +12,7 @@ function showDescription(text, evt) {
 
 function hideDescription() {
     if (!descriptionEl) return;
-    descriptionEl.textContent = '';
+    descriptionEl.innerHTML = '';
     descriptionEl.style.visibility = 'hidden';
 }
 
@@ -72,8 +72,9 @@ function setupHover() {
     items.forEach(div => {
         const id = div.dataset.item;
         if (!id || !itemsInfo[id]) return;
-        const text = `${itemsInfo[id].name} - ${itemsInfo[id].description}`;
-        div.addEventListener('mouseenter', (e) => showDescription(text, e));
+        const effect = itemsInfo[id].effect || itemsInfo[id].description || '';
+        const html = `<strong>${itemsInfo[id].name}</strong><br>${effect}`;
+        div.addEventListener('mouseenter', (e) => showDescription(html, e));
         div.addEventListener('mousemove', (e) => {
             if (descriptionEl && descriptionEl.style.visibility === 'visible') {
                 descriptionEl.style.left = `${e.pageX + 10}px`;


### PR DESCRIPTION
## Summary
- show tooltip with item name and effect on hover in store
- store items now include an `effect` field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855613e0ebc832a9a3523f66cba530a