### PR TITLE
Align store window beside items

### DIFF
--- a/scripts/items.js
+++ b/scripts/items.js
@@ -27,7 +27,8 @@ document.addEventListener('DOMContentLoaded', () => {
         closeWindow();
     });
     document.getElementById('open-store-button')?.addEventListener('click', () => {
-        window.electronAPI.send('store-pet');
+        // Indicar ao processo principal que o comando veio da tela de itens
+        window.electronAPI.send('store-pet', { fromItems: true });
     });
 
     descriptionEl = document.getElementById('item-description');


### PR DESCRIPTION
## Summary
- allow store window to know when it is opened from the items screen
- if opening from items screen, center the items and store windows side by side

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68557033e58c832aa10f0319cf5fce33