### PR TITLE
Remove margin bottom from moves header

### DIFF
--- a/status.html
+++ b/status.html
@@ -213,7 +213,6 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            margin-bottom: 5px;
         }
 
         #train-moves-button {


### PR DESCRIPTION
## Summary
- edit `status.html` to remove the `margin-bottom` style from `#moves-header`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855746e7f30832aa0bcc22338e76c52