### PR TITLE
Add items page button in store

### DIFF
--- a/main.js
+++ b/main.js
@@ -258,7 +258,7 @@ ipcMain.on('train-pet', async () => {
     }
 });
 
-ipcMain.on('itens-pet', () => {
+ipcMain.on('itens-pet', (event, options) => {
     if (currentPet) {
         console.log('Abrindo janela de itens para:', currentPet.name);
         const win = createItemsWindow();
@@ -266,6 +266,27 @@ ipcMain.on('itens-pet', () => {
             win.webContents.on('did-finish-load', () => {
                 win.webContents.send('pet-data', currentPet);
             });
+
+            // Se os itens foram abertos a partir da janela de loja, alinhar as janelas
+            if (options && options.fromStore && storeWindow) {
+                try {
+                    const display = screen.getPrimaryDisplay();
+                    const screenWidth = display.workAreaSize.width;
+                    const screenHeight = display.workAreaSize.height;
+                    const storeBounds = storeWindow.getBounds();
+                    const itemsBounds = win.getBounds();
+                    const totalWidth = storeBounds.width + itemsBounds.width;
+                    const maxHeight = Math.max(storeBounds.height, itemsBounds.height);
+
+                    const startX = Math.round((screenWidth - totalWidth) / 2);
+                    const startY = Math.round((screenHeight - maxHeight) / 2);
+
+                    win.setPosition(startX, startY);
+                    storeWindow.setPosition(startX + itemsBounds.width, startY);
+                } catch (err) {
+                    console.error('Erro ao posicionar janelas:', err);
+                }
+            }
         }
     } else {
         console.error('Nenhum pet selecionado para abrir itens');

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -30,6 +30,10 @@ document.addEventListener('DOMContentLoaded', () => {
     descriptionEl = document.getElementById('store-item-description');
     loadItemsInfo();
 
+    document.getElementById('open-items-button')?.addEventListener('click', () => {
+        window.electronAPI.send('itens-pet', { fromStore: true });
+    });
+
     document.querySelectorAll('.buy-button').forEach(btn => {
         btn.addEventListener('click', () => {
             const item = btn.dataset.item;

--- a/store.html
+++ b/store.html
@@ -66,6 +66,12 @@
             height: 32px;
             image-rendering: pixelated;
         }
+        #open-items-button {
+            position: absolute;
+            top: 35px;
+            right: 5px;
+            align-self: unset;
+        }
         #store-items {
             flex:1;
             display:flex;
@@ -116,6 +122,7 @@
             <img id="store-coin-icon" src="assets/icons/kadircoin.png" alt="Moedas" />
             <span id="store-coin-count">0</span>
         </div>
+        <button class="button small-button" id="open-items-button">Itens</button>
         <div id="store-items">
             <div class="store-item" data-item="healthPotion">
                 <img src="Assets/Shop/health-potion.png" alt="Health Potion">


### PR DESCRIPTION
## Summary
- add button in `store.html` to open Items window
- implement handler in `store.js` to open Items window
- adjust `main.js` to position store and items windows together

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855913d8d90832ab83649ee4fe885c4