### PR TITLE
Add exit confirmation

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -86,6 +86,9 @@ document.getElementById('load-button').addEventListener('click', () => {
 
 document.getElementById('exit-button').addEventListener('click', () => {
     console.log('Botão Sair clicado');
+    if (!confirm('Tem certeza que deseja sair?')) {
+        return;
+    }
     if (window.electronAPI) {
         console.log('Enviando exit-app');
         window.electronAPI.send('exit-app');

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -190,7 +190,9 @@ function setImageWithFallback(imgElement, relativePath) {
     window.electronAPI.send('open-load-pet-window');
     } else if (action === 'exit') {
     console.log('Sair');
-    window.electronAPI.send('exit-app');
+    if (confirm('Tem certeza que deseja sair?')) {
+        window.electronAPI.send('exit-app');
+    }
     } else if (action === 'train-pet') {
     console.log('Treinar Pet');
     window.electronAPI.send('train-pet');


### PR DESCRIPTION
## Summary
- prompt for confirmation before closing the app from **Start** screen and from the menu

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68559a5fe938832abd215a957b3295a0