### PR TITLE
Add exit confirmation modals

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,6 +282,39 @@
             max-width: 200px;
             line-height: 1.2;
         }
+
+        /* Modal de confirmação de saída */
+        #exit-confirm-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            justify-content: center;
+            align-items: center;
+            z-index: 50;
+        }
+
+        #exit-confirm-box {
+            background-color: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 20px;
+            text-align: center;
+            font-family: 'PixelOperator', sans-serif;
+        }
+
+        #exit-confirm-box p {
+            margin-bottom: 10px;
+        }
+
+        #exit-confirm-box .confirm-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
     </style>
 </head>
 
@@ -322,6 +355,16 @@
             <img id="happiness-warning" class="warning-image" src="Assets/Shop/sad.png" alt="Felicidade baixa" style="image-rendering: pixelated;">
             <!-- Alerta de batalha -->
             <div id="battle-alert"></div>
+        </div>
+    </div>
+
+    <div id="exit-confirm-overlay">
+        <div id="exit-confirm-box">
+            <p>Tem certeza que deseja sair?</p>
+            <div class="confirm-buttons">
+                <button class="button small-button" id="exit-confirm-yes">Sair</button>
+                <button class="button small-button" id="exit-confirm-no">Cancelar</button>
+            </div>
         </div>
     </div>
 

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -84,16 +84,29 @@ document.getElementById('load-button').addEventListener('click', () => {
     }
 });
 
+const exitOverlay = document.getElementById('exit-confirm-overlay');
+const exitYesBtn = document.getElementById('exit-confirm-yes');
+const exitNoBtn = document.getElementById('exit-confirm-no');
+
 document.getElementById('exit-button').addEventListener('click', () => {
     console.log('Botão Sair clicado');
-    if (!confirm('Tem certeza que deseja sair?')) {
-        return;
+    if (exitOverlay) {
+        exitOverlay.style.display = 'flex';
     }
+});
+
+exitYesBtn?.addEventListener('click', () => {
     if (window.electronAPI) {
         console.log('Enviando exit-app');
         window.electronAPI.send('exit-app');
     } else {
         console.error('electronAPI não está disponível para enviar exit-app');
+    }
+});
+
+exitNoBtn?.addEventListener('click', () => {
+    if (exitOverlay) {
+        exitOverlay.style.display = 'none';
     }
 });
 

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -1,5 +1,9 @@
 import { rarityGradients } from './constants.js';
 
+const exitOverlay = document.getElementById('exit-confirm-overlay');
+const exitYesBtn = document.getElementById('exit-confirm-yes');
+const exitNoBtn = document.getElementById('exit-confirm-no');
+
 function setImageWithFallback(imgElement, relativePath) {
     if (!imgElement) return;
     if (!relativePath) {
@@ -190,8 +194,8 @@ function setImageWithFallback(imgElement, relativePath) {
     window.electronAPI.send('open-load-pet-window');
     } else if (action === 'exit') {
     console.log('Sair');
-    if (confirm('Tem certeza que deseja sair?')) {
-        window.electronAPI.send('exit-app');
+    if (exitOverlay) {
+        exitOverlay.style.display = 'flex';
     }
     } else if (action === 'train-pet') {
     console.log('Treinar Pet');
@@ -229,6 +233,16 @@ function setImageWithFallback(imgElement, relativePath) {
     }, 3000);
     } else {
     console.error('Elemento #battle-alert não encontrado');
+    }
+    });
+
+    exitYesBtn?.addEventListener('click', () => {
+    window.electronAPI.send('exit-app');
+    });
+
+    exitNoBtn?.addEventListener('click', () => {
+    if (exitOverlay) {
+        exitOverlay.style.display = 'none';
     }
     });
 

--- a/start.html
+++ b/start.html
@@ -82,6 +82,39 @@
         #mute-button:hover {
             background-color: #3a4350;
         }
+
+        /* Modal de confirmação de saída */
+        #exit-confirm-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            justify-content: center;
+            align-items: center;
+            z-index: 50;
+        }
+
+        #exit-confirm-box {
+            background-color: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 20px;
+            text-align: center;
+            font-family: 'PixelOperator', sans-serif;
+        }
+
+        #exit-confirm-box p {
+            margin-bottom: 10px;
+        }
+
+        #exit-confirm-box .confirm-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
     </style>
 </head>
 
@@ -99,6 +132,16 @@
         <source src="Assets/Sounds/SagadoNorte.mp3" type="audio/mpeg">
         Seu navegador não suporta o elemento de áudio.
     </audio>
+
+    <div id="exit-confirm-overlay">
+        <div id="exit-confirm-box">
+            <p>Tem certeza que deseja sair?</p>
+            <div class="confirm-buttons">
+                <button class="button small-button" id="exit-confirm-yes">Sair</button>
+                <button class="button small-button" id="exit-confirm-no">Cancelar</button>
+            </div>
+        </div>
+    </div>
 
     <script src="scripts/start.js"></script>
 


### PR DESCRIPTION
## Summary
- add custom modal to confirm exiting the game
- wire the modal up on Start and Tray screens

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68559b68a530832aa2ab828178e7c940