### PR TITLE
Add Fôlego Puro attack

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -108,5 +108,16 @@
     "effect": "paralisia",
     "cost": 7,
     "level": 2
+  },
+  {
+    "name": "Fôlego Puro",
+    "description": "Sopro de energia purificada que causa grande dano ao inimigo.",
+    "rarity": "Incomum",
+    "elements": ["puro"],
+    "species": ["Ave", "Fera", "Draconídeo"],
+    "power": 18,
+    "effect": "nenhum",
+    "cost": 10,
+    "level": 3
   }
 ]


### PR DESCRIPTION
## Summary
- add the level 3 move **Fôlego Puro** for pure element

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6855acd2a560832aa4c48a58019dec00