### PR TITLE
Implement random map events

### DIFF
--- a/journey-mode.html
+++ b/journey-mode.html
@@ -123,6 +123,13 @@
                 <div class="path-subpoint" style="top: 485px;left: 887px;"></div>
 
                 <div id="map-tooltip" style="display: none; left: 900px; top: 170px;"><img src="Assets/Modes/Journeys/cave_ruin.png" alt="preview"><div class="tooltip-name"></div></div>
+                <div id="event-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
+                    <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
+                        <img id="event-modal-icon" src="" alt="" style="width:64px; height:64px; image-rendering:pixelated; display:block; margin:0 auto 5px;" />
+                        <div id="event-modal-text" style="margin-bottom:8px;"></div>
+                        <button id="event-modal-close" class="button small-button">OK</button>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/main.js
+++ b/main.js
@@ -757,6 +757,34 @@ ipcMain.on('use-item', async (event, item) => {
     }
 });
 
+ipcMain.on('reward-pet', async (event, reward) => {
+    if (!currentPet || !reward) return;
+    if (reward.item) {
+        if (!currentPet.items) currentPet.items = {};
+        const qty = reward.qty || 1;
+        currentPet.items[reward.item] = (currentPet.items[reward.item] || 0) + qty;
+    }
+    if (reward.coins) {
+        currentPet.coins = (currentPet.coins || 0) + reward.coins;
+    }
+    if (reward.kadirPoints) {
+        currentPet.kadirPoints = (currentPet.kadirPoints || 0) + reward.kadirPoints;
+    }
+
+    try {
+        await petManager.updatePet(currentPet.petId, {
+            items: currentPet.items,
+            coins: currentPet.coins,
+            kadirPoints: currentPet.kadirPoints
+        });
+        BrowserWindow.getAllWindows().forEach(w => {
+            if (w.webContents) w.webContents.send('pet-data', currentPet);
+        });
+    } catch (err) {
+        console.error('Erro ao aplicar recompensa:', err);
+    }
+});
+
 ipcMain.on('learn-move', async (event, move) => {
     if (!currentPet) return;
     if (!currentPet.moves) currentPet.moves = [];

--- a/preload.js
+++ b/preload.js
@@ -29,6 +29,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'resize-journey-window',
             'set-mute-state',
             'get-journey-images',
+            'reward-pet',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
             'close-start-window'  // Fechar a janela de start
         ];

--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -15,6 +15,54 @@ document.addEventListener('DOMContentLoaded', () => {
     const tooltipImg = tooltip.querySelector('img');
     const tooltipName = tooltip.querySelector('.tooltip-name');
 
+    const eventModal = document.getElementById('event-modal');
+    const eventModalIcon = document.getElementById('event-modal-icon');
+    const eventModalText = document.getElementById('event-modal-text');
+    const eventModalClose = document.getElementById('event-modal-close');
+    eventModalClose?.addEventListener('click', () => {
+        if (eventModal) eventModal.style.display = 'none';
+    });
+
+    let itemsData = [];
+    fetch('data/items.json').then(r => r.json()).then(d => { itemsData = d; }).catch(() => {});
+
+    function showEventModal(text, icon) {
+        if (!eventModal) return;
+        if (eventModalIcon) {
+            if (icon) {
+                eventModalIcon.src = icon;
+                eventModalIcon.style.display = 'block';
+            } else {
+                eventModalIcon.style.display = 'none';
+            }
+        }
+        if (eventModalText) eventModalText.textContent = text;
+        eventModal.style.display = 'flex';
+    }
+
+    function handleRandomEvent(img) {
+        const roll = Math.random() * 100;
+        if (roll < 70) {
+            window.electronAPI?.send('open-journey-scene-window', { background: img });
+            return;
+        } else if (roll < 90) {
+            if (itemsData.length) {
+                const item = itemsData[Math.floor(Math.random() * itemsData.length)];
+                window.electronAPI?.send('reward-pet', { item: item.id, qty: 1 });
+                showEventModal(`Você encontrou 1 ${item.name}!`, item.icon);
+            }
+        } else if (roll < 95) {
+            const coins = Math.floor(Math.random() * 5) + 1;
+            window.electronAPI?.send('reward-pet', { coins });
+            showEventModal(`Você encontrou ${coins} moedas!`, 'assets/icons/kadircoin.png');
+        } else if (roll < 97) {
+            window.electronAPI?.send('reward-pet', { kadirPoints: 1 });
+            showEventModal('Você encontrou 1 DNA Kadir!', 'assets/icons/dna-kadir.png');
+        } else {
+            showEventModal('Nada encontrado...', null);
+        }
+    }
+
     function positionTooltip(event) {
         let left = event.pageX + 10;
         let top = event.pageY - tooltip.offsetHeight - 10;
@@ -70,7 +118,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const img = point.dataset.image;
             if (img) {
                 setCurrent(point);
-                window.electronAPI?.send('open-journey-scene-window', { background: img });
+                handleRandomEvent(img);
             }
         });
     });


### PR DESCRIPTION
## Summary
- add event modal to journey mode
- implement random event logic in `journey-map.js`
- allow renderer to send `reward-pet` IPC
- handle `reward-pet` in main process

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856055f3268832aafa537911d567a8e