### PR TITLE
Add journey action menu

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -161,6 +161,47 @@
             background-image: linear-gradient(to bottom, #00d2ff, #0083ff);
         }
 
+        /* Menu de ações na parte inferior */
+        #action-menu {
+            position: absolute;
+            bottom: 10px;
+            left: 50%;
+            transform: translateX(-50%);
+            display: flex;
+            gap: 10px;
+            z-index: 2;
+        }
+
+        .sub-menu {
+            position: absolute;
+            bottom: 60px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 8px;
+            display: none;
+            flex-direction: column;
+            gap: 5px;
+            z-index: 2;
+        }
+
+        .message-box {
+            position: absolute;
+            bottom: 120px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 6px 12px;
+            display: none;
+            z-index: 2;
+            font-family: 'PixelOperator', sans-serif;
+            color: #ffffff;
+        }
+
     </style>
 </head>
 <body>
@@ -203,6 +244,16 @@
 
         <img id="player-pet" class="pet" src="" alt="pet">
         <img id="enemy-pet" class="pet" src="" alt="inimigo">
+
+        <div id="action-menu">
+            <button id="fight-btn" class="button small-button">Lutar</button>
+            <button id="items-btn" class="button small-button">Itens</button>
+            <button id="run-btn" class="button small-button">Fugir</button>
+        </div>
+
+        <div id="moves-menu" class="sub-menu"></div>
+        <div id="items-menu" class="sub-menu"></div>
+        <div id="message-box" class="message-box"></div>
     </div>
     <script src="scripts/journey-scene.js"></script>
 </body>

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -10,6 +10,80 @@ function assetPath(relative) {
     return `Assets/Mons/${cleaned}`;
 }
 
+let pet = null;
+let itemsInfo = {};
+let playerHealth = 100;
+let playerMaxHealth = 100;
+let enemyHealth = 100;
+
+async function loadItemsInfo() {
+    try {
+        const resp = await fetch('data/items.json');
+        const data = await resp.json();
+        itemsInfo = {};
+        data.forEach(it => { itemsInfo[it.id] = it; });
+    } catch (err) {
+        console.error('Erro ao carregar info dos itens:', err);
+    }
+}
+
+function hideMenus() {
+    document.getElementById('moves-menu').style.display = 'none';
+    document.getElementById('items-menu').style.display = 'none';
+}
+
+function showMessage(text) {
+    const box = document.getElementById('message-box');
+    if (!box) return;
+    box.textContent = text;
+    box.style.display = 'block';
+    setTimeout(() => { box.style.display = 'none'; }, 2000);
+}
+
+function updateMoves() {
+    const menu = document.getElementById('moves-menu');
+    if (!menu) return;
+    menu.innerHTML = '';
+    if (!pet || !Array.isArray(pet.moves)) return;
+    pet.moves.forEach(move => {
+        const btn = document.createElement('button');
+        btn.className = 'button small-button';
+        btn.textContent = move.name;
+        menu.appendChild(btn);
+    });
+}
+
+function updateItems() {
+    const menu = document.getElementById('items-menu');
+    if (!menu) return;
+    menu.innerHTML = '';
+    if (!pet || !pet.items) return;
+    Object.keys(pet.items).forEach(id => {
+        const qty = pet.items[id];
+        if (qty <= 0) return;
+        const info = itemsInfo[id] || { name: id };
+        const btn = document.createElement('button');
+        btn.className = 'button small-button';
+        btn.textContent = `${info.name} x${qty}`;
+        btn.addEventListener('click', () => {
+            window.electronAPI.send('use-item', id);
+        });
+        menu.appendChild(btn);
+    });
+}
+
+function attemptFlee() {
+    let chance = 0.5;
+    if (playerHealth >= enemyHealth) chance += 0.25; else chance -= 0.25;
+    chance = Math.max(0.1, Math.min(0.9, chance));
+    if (Math.random() < chance) {
+        showMessage('Fuga bem-sucedida!');
+        setTimeout(closeWindow, 1500);
+    } else {
+        showMessage('Fuga falhou!');
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const bg = document.getElementById('scene-bg');
     const player = document.getElementById('player-pet');
@@ -17,12 +91,43 @@ document.addEventListener('DOMContentLoaded', () => {
     const playerFront = document.getElementById('player-front');
     const enemyFront = document.getElementById('enemy-front');
     const enemyName = document.getElementById('enemy-name');
+    loadItemsInfo();
 
     document.getElementById('close-journey-scene')?.addEventListener('click', closeWindow);
     document.getElementById('back-journey-scene')?.addEventListener('click', () => {
         window.electronAPI.send('open-journey-mode-window');
         closeWindow();
     });
+
+    const fightBtn = document.getElementById('fight-btn');
+    const itemsBtn = document.getElementById('items-btn');
+    const runBtn = document.getElementById('run-btn');
+
+    fightBtn?.addEventListener('click', () => {
+        const menu = document.getElementById('moves-menu');
+        if (!menu) return;
+        if (menu.style.display === 'none' || menu.style.display === '') {
+            hideMenus();
+            updateMoves();
+            menu.style.display = 'flex';
+        } else {
+            menu.style.display = 'none';
+        }
+    });
+
+    itemsBtn?.addEventListener('click', () => {
+        const menu = document.getElementById('items-menu');
+        if (!menu) return;
+        if (menu.style.display === 'none' || menu.style.display === '') {
+            hideMenus();
+            updateItems();
+            menu.style.display = 'flex';
+        } else {
+            menu.style.display = 'none';
+        }
+    });
+
+    runBtn?.addEventListener('click', attemptFlee);
 
     window.electronAPI.on('scene-data', (event, data) => {
         if (data.background && bg) bg.src = data.background;
@@ -40,5 +145,24 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (data.enemyName && enemyName) enemyName.textContent = data.enemyName;
+    });
+
+    window.electronAPI.on('pet-data', (event, data) => {
+        if (!data) return;
+        pet = data;
+        playerHealth = data.currentHealth ?? playerHealth;
+        playerMaxHealth = data.maxHealth ?? playerMaxHealth;
+        const healthFill = document.getElementById('player-health-fill');
+        const energyFill = document.getElementById('player-energy-fill');
+        if (healthFill) {
+            const percent = (playerHealth / playerMaxHealth) * 100;
+            healthFill.style.width = `${percent}%`;
+        }
+        if (energyFill) {
+            const percent = (data.energy || 0);
+            energyFill.style.width = `${percent}%`;
+        }
+        updateMoves();
+        updateItems();
     });
 });


### PR DESCRIPTION
## Summary
- add an action menu to `journey-scene.html`
- implement logic for fight, items and flee in `journey-scene.js`
- load item data and update HUD values when pet data changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856079d0110832a945de97484883049