### PR TITLE
Implement battle turns and item icons in journey scene

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -198,6 +198,18 @@
             z-index: 2;
         }
 
+        .item-button {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+
+        .item-button img {
+            width: 24px;
+            height: 24px;
+            image-rendering: pixelated;
+        }
+
         .message-box {
             position: absolute;
             bottom: 120px;


### PR DESCRIPTION
## Summary
- add item icon styles
- allow moves to trigger player attack animations
- show item icons when viewing items menu
- implement a basic turn system considering debuffs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68560c769850832ab668ad5948737054