### PR TITLE
Fix item icons display in journey scene

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -202,6 +202,7 @@
             display: flex;
             align-items: center;
             gap: 4px;
+            justify-content: flex-start;
         }
 
         .item-button img {

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -96,10 +96,21 @@ function updateItems() {
         const info = itemsInfo[id] || { name: id };
         const btn = document.createElement('button');
         btn.className = 'button small-button item-button';
-        btn.innerHTML = `<img src="${info.icon}" alt="${info.name}"><span>${info.name} x${qty}</span>`;
+
+        const img = document.createElement('img');
+        img.src = info.icon;
+        img.alt = info.name;
+
+        const label = document.createElement('span');
+        label.textContent = `${info.name} x ${qty}`;
+
+        btn.appendChild(img);
+        btn.appendChild(label);
+
         btn.addEventListener('click', () => {
             window.electronAPI.send('use-item', id);
         });
+
         menu.appendChild(btn);
     });
 }


### PR DESCRIPTION
## Summary
- ensure item buttons show icon, name, and quantity
- tweak styles so icons align left of item names

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68560dad9ab0832a9ff39d0599c542f7