### PR TITLE
Implement victory modal with rewards

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -279,6 +279,13 @@
         <div id="moves-menu" class="sub-menu"></div>
         <div id="items-menu" class="sub-menu"></div>
         <div id="message-box" class="message-box"></div>
+        <div id="victory-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
+            <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
+                <div id="victory-text" style="margin-bottom:8px;">Parabéns! Você venceu!</div>
+                <div id="victory-reward" style="margin-bottom:8px;"></div>
+                <button id="victory-close" class="button small-button">OK</button>
+            </div>
+        </div>
     </div>
     <script src="scripts/journey-scene.js"></script>
 </body>

--- a/main.js
+++ b/main.js
@@ -774,12 +774,29 @@ ipcMain.on('reward-pet', async (event, reward) => {
     if (reward.kadirPoints) {
         currentPet.kadirPoints = (currentPet.kadirPoints || 0) + reward.kadirPoints;
     }
+    if (reward.experience) {
+        currentPet.experience = (currentPet.experience || 0) + reward.experience;
+        let requiredXp = getRequiredXpForNextLevel(currentPet.level);
+        while (currentPet.experience >= requiredXp && currentPet.level < 100) {
+            currentPet.level += 1;
+            currentPet.experience -= requiredXp;
+            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 1;
+            increaseAttributesOnLevelUp(currentPet);
+            requiredXp = getRequiredXpForNextLevel(currentPet.level);
+        }
+    }
 
     try {
         await petManager.updatePet(currentPet.petId, {
             items: currentPet.items,
             coins: currentPet.coins,
-            kadirPoints: currentPet.kadirPoints
+            kadirPoints: currentPet.kadirPoints,
+            level: currentPet.level,
+            experience: currentPet.experience,
+            attributes: currentPet.attributes,
+            maxHealth: currentPet.maxHealth,
+            currentHealth: currentPet.currentHealth,
+            energy: currentPet.energy
         });
         BrowserWindow.getAllWindows().forEach(w => {
             if (w.webContents) w.webContents.send('pet-data', currentPet);


### PR DESCRIPTION
## Summary
- add victory modal in journey-scene
- handle battle end conditions and reward logic
- implement random reward generation
- extend `reward-pet` IPC to support experience gain and level ups

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68561289b6a8832aaa09644b90d3e39e