### PR TITLE
Implement battle streak happiness and move energy cost

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -30,6 +30,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'set-mute-state',
             'get-journey-images',
             'reward-pet',
+            'use-move',
+            'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
             'close-start-window'  // Fechar a janela de start
         ];

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -99,6 +99,8 @@ async function createPet(petData) {
         energy: petData.energy || 100,
         coins: petData.coins || 20,
         kadirPoints: petData.kadirPoints || 5,
+        winStreak: 0,
+        lossStreak: 0,
         currentHealth: petData.currentHealth || (petData.attributes?.life || 100),
         maxHealth: petData.maxHealth || (petData.attributes?.life || 100),
         moves: [],
@@ -143,11 +145,17 @@ async function listPets() {
                     if (pet.coins === undefined) {
                         pet.coins = 20;
                     }
-                    if (pet.items === undefined) {
-                        pet.items = {};
+                   if (pet.items === undefined) {
+                       pet.items = {};
+                   }
+                   if (pet.statusEffects === undefined) {
+                       pet.statusEffects = [];
+                   }
+                    if (pet.winStreak === undefined) {
+                        pet.winStreak = 0;
                     }
-                    if (pet.statusEffects === undefined) {
-                        pet.statusEffects = [];
+                    if (pet.lossStreak === undefined) {
+                        pet.lossStreak = 0;
                     }
                     pet.fileName = file; // Garantir que o fileName esteja atualizado
                     ensureStatusImage(pet);
@@ -183,11 +191,17 @@ async function loadPet(petId) {
         if (pet.coins === undefined) {
             pet.coins = 20;
         }
-        if (pet.items === undefined) {
-            pet.items = {};
+       if (pet.items === undefined) {
+           pet.items = {};
+       }
+       if (pet.statusEffects === undefined) {
+           pet.statusEffects = [];
+       }
+        if (pet.winStreak === undefined) {
+            pet.winStreak = 0;
         }
-        if (pet.statusEffects === undefined) {
-            pet.statusEffects = [];
+        if (pet.lossStreak === undefined) {
+            pet.lossStreak = 0;
         }
         ensureStatusImage(pet);
         if (!pet.knownMoves) {


### PR DESCRIPTION
## Summary
- add new IPC channels for moves and battle results
- track win and loss streaks in pets
- update happiness based on battle outcomes
- decrease energy when using moves
- show move energy cost in the journey scene

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856153420e8832abd0084d2c69e748c