### PR TITLE
Fix data paths for single-window mode

### DIFF
--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -33,7 +33,7 @@ const specieBioImages = Object.fromEntries(
 let questions = [];
 
 function loadQuestions() {
-    return fetch('data/questions.json')
+    return fetch('../data/questions.json')
         .then(response => response.json())
         .then(data => {
             questions = data;

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -44,7 +44,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function loadItemsInfo() {
     try {
-        const response = await fetch('data/items.json');
+        const response = await fetch('../data/items.json');
         const data = await response.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });

--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     let itemsData = [];
-    fetch('data/items.json').then(r => r.json()).then(d => { itemsData = d; }).catch(() => {});
+    fetch('../data/items.json').then(r => r.json()).then(d => { itemsData = d; }).catch(() => {});
 
     function showEventModal(text, icon) {
         if (!eventModal) return;

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -25,7 +25,7 @@ let enemyAttackSrc = '';
 
 async function loadItemsInfo() {
     try {
-        const resp = await fetch('data/items.json');
+        const resp = await fetch('../data/items.json');
         const data = await resp.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });
@@ -37,7 +37,7 @@ async function loadItemsInfo() {
 
 async function loadStatusEffectsInfo() {
     try {
-        const resp = await fetch('data/status-effects.json');
+        const resp = await fetch('../data/status-effects.json');
         const data = await resp.json();
         statusEffectsInfo = {};
         data.forEach(se => { statusEffectsInfo[se.id] = se; });

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function loadItemsInfo() {
     try {
-        const response = await fetch('data/items.json');
+        const response = await fetch('../data/items.json');
         const data = await response.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -70,7 +70,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function loadMoves() {
     try {
-        const response = await fetch('data/moves.json');
+        const response = await fetch('../data/moves.json');
         const moves = await response.json();
         renderMoves(moves);
     } catch (err) {


### PR DESCRIPTION
## Summary
- fix resource fetching in create-pet flow and other modules

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a0f203e0832a9359210395b9fedf