### PR TITLE
Improve single window support

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -53,7 +53,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'show-store-error',
             'pet-created', // Novo canal pra receber a confirmação do pet criado
             'scene-data',
-            'fade-out-start-music' // Sinalizar o fade-out da música de start
+            'fade-out-start-music', // Sinalizar o fade-out da música de start
+            'navigate-to'
         ];
         if (validChannels.includes(channel)) {
             console.log(`Registrando listener para o canal: ${channel}`);
@@ -100,7 +101,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     openOptionsWindow: () => { ipcRenderer.send('open-options-window'); },
     setViewMode: (mode) => { ipcRenderer.invoke('set-view-mode', mode); },
-    getViewMode: () => ipcRenderer.invoke('get-view-mode')
+    getViewMode: () => ipcRenderer.invoke('get-view-mode'),
+    getCurrentPet: () => ipcRenderer.invoke('get-current-pet')
 });
 
 console.log('electronAPI exposto com sucesso');

--- a/router.js
+++ b/router.js
@@ -50,5 +50,8 @@ async function navigateTo(page){
 }
 window.navigateTo = navigateTo;
 window.addEventListener('DOMContentLoaded',()=>{
+  if (window.electronAPI && window.electronAPI.on) {
+    window.electronAPI.on('navigate-to', (e, page) => navigateTo(page));
+  }
   navigateTo('screens/start.html');
 });

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -34,6 +34,17 @@ document.addEventListener('DOMContentLoaded', () => {
     descriptionEl = document.getElementById('item-description');
     loadItemsInfo();
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) {
+                pet = data;
+                const countEl = document.getElementById('coin-count');
+                if (countEl) countEl.textContent = pet.coins ?? 0;
+                updateItems();
+            }
+        });
+    }
+
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
         const countEl = document.getElementById('coin-count');

--- a/scripts/journey-mode.js
+++ b/scripts/journey-mode.js
@@ -34,6 +34,15 @@ document.addEventListener('DOMContentLoaded', () => {
     const loading = document.getElementById('loading');
     const grid = document.getElementById('missions-grid');
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data && data.level) {
+                petLevel = data.level;
+                updateLocks();
+            }
+        });
+    }
+
     window.electronAPI.getJourneyImages().then(files => {
         // Ordenar as imagens conforme a ordem definida em missionOrder
         const orderMap = missionOrder.reduce((acc, name, index) => {

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -315,6 +315,17 @@ document.addEventListener('DOMContentLoaded', () => {
     loadItemsInfo();
     loadStatusEffectsInfo().then(updateStatusIcons);
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) {
+                pet = data;
+                playerHealth = data.currentHealth ?? playerHealth;
+                playerMaxHealth = data.maxHealth ?? playerMaxHealth;
+                updateHealthBars();
+            }
+        });
+    }
+
     document.getElementById('close-journey-scene')?.addEventListener('click', closeWindow);
     document.getElementById('back-journey-scene')?.addEventListener('click', () => {
         window.electronAPI.send('open-journey-mode-window');

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -329,6 +329,14 @@ document.addEventListener('DOMContentLoaded', () => {
         console.warn('train-moves-button element not found');
     }
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) {
+                loadPet(data);
+            }
+        });
+    }
+
     // Registrar o listener para o evento pet-data dentro do DOMContentLoaded
     window.electronAPI.on('pet-data', (event, petData) => {
         console.log('Dados do pet recebidos via IPC:', petData);

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -41,6 +41,16 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) {
+                pet = data;
+                const countEl = document.getElementById('store-coin-count');
+                if (countEl) countEl.textContent = pet.coins ?? 0;
+            }
+        });
+    }
+
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
         const countEl = document.getElementById('store-coin-count');

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -45,6 +45,20 @@ document.addEventListener('DOMContentLoaded', () => {
     descriptionEl = document.getElementById('move-description');
     trainAlert = document.getElementById('train-alert');
 
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) {
+                pet = data;
+                if (!pet.knownMoves) {
+                    pet.knownMoves = pet.moves ? [...pet.moves] : [];
+                }
+                const kpEl = document.getElementById('train-kadir-points-value');
+                if (kpEl) kpEl.textContent = pet.kadirPoints ?? 0;
+                loadMoves();
+            }
+        });
+    }
+
     window.electronAPI.on('pet-data', (event, data) => {
         pet = data;
         if (!pet.knownMoves) {

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -133,6 +133,12 @@ function setImageWithFallback(imgElement, relativePath) {
     
     // Carregar dados iniciais
     loadPet(petData);
+
+    if (window.electronAPI.getCurrentPet) {
+        window.electronAPI.getCurrentPet().then(data => {
+            if (data) loadPet(data);
+        });
+    }
     
     // Toggle entre raridade e textura
     let showRarity = true;


### PR DESCRIPTION
## Summary
- route screens via a single window when enabled
- expose new `getCurrentPet` API from main process
- update renderer scripts to fetch pet data when loaded
- listen for `navigate-to` messages in router

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a29488b0832a900745855a3850cb