### PR TITLE
Fix asset paths for single-window mode

### DIFF
--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -31,9 +31,10 @@ const specieBioImages = Object.fromEntries(
 // Perguntas carregadas de data/questions.json
 
 let questions = [];
+const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
 
 function loadQuestions() {
-    return fetch('../data/questions.json')
+    return fetch(`${dataPrefix}questions.json`)
         .then(response => response.json())
         .then(data => {
             questions = data;

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -53,9 +53,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
+
 async function loadItemsInfo() {
     try {
-        const response = await fetch('../data/items.json');
+        const response = await fetch(`${dataPrefix}items.json`);
         const data = await response.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });

--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -23,8 +23,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (eventModal) eventModal.style.display = 'none';
     });
 
+    const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
     let itemsData = [];
-    fetch('../data/items.json').then(r => r.json()).then(d => { itemsData = d; }).catch(() => {});
+    fetch(`${dataPrefix}items.json`).then(r => r.json()).then(d => { itemsData = d; }).catch(() => {});
 
     function showEventModal(text, icon) {
         if (!eventModal) return;

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -22,10 +22,11 @@ let playerIdleSrc = '';
 let playerAttackSrc = '';
 let enemyIdleSrc = '';
 let enemyAttackSrc = '';
+const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
 
 async function loadItemsInfo() {
     try {
-        const resp = await fetch('../data/items.json');
+        const resp = await fetch(`${dataPrefix}items.json`);
         const data = await resp.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });
@@ -37,7 +38,7 @@ async function loadItemsInfo() {
 
 async function loadStatusEffectsInfo() {
     try {
-        const resp = await fetch('../data/status-effects.json');
+        const resp = await fetch(`${dataPrefix}status-effects.json`);
         const data = await resp.json();
         statusEffectsInfo = {};
         data.forEach(se => { statusEffectsInfo[se.id] = se; });

--- a/scripts/store.js
+++ b/scripts/store.js
@@ -69,9 +69,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
+
 async function loadItemsInfo() {
     try {
-        const response = await fetch('../data/items.json');
+        const response = await fetch(`${dataPrefix}items.json`);
         const data = await response.json();
         itemsInfo = {};
         data.forEach(it => { itemsInfo[it.id] = it; });

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -82,9 +82,11 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 });
 
+const dataPrefix = window.location.pathname.endsWith('/app.html') ? 'data/' : '../data/';
+
 async function loadMoves() {
     try {
-        const response = await fetch('../data/moves.json');
+        const response = await fetch(`${dataPrefix}moves.json`);
         const moves = await response.json();
         renderMoves(moves);
     } catch (err) {


### PR DESCRIPTION
## Summary
- adjust data file paths when navigating via app.html
- ensure questions, items, and other data load in single-window mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856a51f3178832a9b04cc4f1b158469