### PR TITLE
Fix health reset and map backgrounds

### DIFF
--- a/main.js
+++ b/main.js
@@ -778,6 +778,19 @@ ipcMain.on('use-move', async (event, move) => {
     }
 });
 
+ipcMain.on('update-health', async (event, newHealth) => {
+    if (!currentPet) return;
+    currentPet.currentHealth = Math.max(0, Math.min(currentPet.maxHealth, newHealth));
+    try {
+        await petManager.updatePet(currentPet.petId, { currentHealth: currentPet.currentHealth });
+        BrowserWindow.getAllWindows().forEach(w => {
+            if (w.webContents) w.webContents.send('pet-data', currentPet);
+        });
+    } catch (err) {
+        console.error('Erro ao atualizar vida do pet:', err);
+    }
+});
+
 ipcMain.on('reward-pet', async (event, reward) => {
     if (!currentPet || !reward) return;
     if (reward.item) {

--- a/preload.js
+++ b/preload.js
@@ -31,6 +31,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'get-journey-images',
             'reward-pet',
             'use-move',
+            'update-health',
             'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
             'close-start-window'  // Fechar a janela de start

--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -123,6 +123,13 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     route.forEach((point, idx) => {
+        let nextBackground = '';
+        for (let j = idx + 1; j < route.length; j++) {
+            if (route[j].classList.contains('path-point')) {
+                nextBackground = route[j].dataset.image || '';
+                break;
+            }
+        }
         if (point.classList.contains('path-point')) {
             point.addEventListener('mouseenter', event => {
                 const img = point.dataset.image;
@@ -150,7 +157,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     handleBossFight(img);
                 }
             } else {
-                handleRandomEvent('');
+                handleRandomEvent(nextBackground);
             }
             advancePoint();
         });

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -190,6 +190,7 @@ function applyStatusEffects() {
         playerHealth = Math.max(0, playerHealth - dmg);
     }
     updateHealthBars();
+    window.electronAPI.send('update-health', playerHealth);
 }
 
 function generateReward() {
@@ -296,6 +297,7 @@ function enemyAction() {
     playAttackAnimation(enemyImg, enemyIdleSrc, enemyAttackSrc, () => {
         playerHealth = Math.max(0, playerHealth - 8);
         updateHealthBars();
+        window.electronAPI.send('update-health', playerHealth);
         if (playerHealth <= 0) {
             concludeBattle(false);
         } else {


### PR DESCRIPTION
## Summary
- keep pet HP in sync by updating health after damage
- expose `update-health` IPC channel in the preload script
- compute next point background for subpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856b010777c832ab19033543ba9ced1