### PR TITLE
Add pet details to About tab

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -1,4 +1,10 @@
 import { rarityGradients, rarityColors, specieBioImages, specieDirs } from './constants.js';
+
+function getRequiredXpForNextLevel(level) {
+    const baseXp = 100;
+    const scale = 1.2;
+    return Math.round(baseXp * Math.pow(level, 1.5) * scale);
+}
 console.log('status.js carregado com sucesso');
 
 let pet = {};
@@ -96,12 +102,16 @@ function updateStatus() {
     const statusPetImage = document.getElementById('status-pet-image');
     const statusBioImage = document.getElementById('status-bio-image');
     const bioText = document.getElementById('bio-text');
+    const xpBarFill = document.getElementById('xp-bar-fill');
+    const xpText = document.getElementById('xp-text');
+    const specieText = document.getElementById('specie-text');
+    const elementText = document.getElementById('element-text');
     const titleBarElement = document.getElementById('title-bar-element');
     const titleBarPetName = document.getElementById('title-bar-pet-name');
     const statusPetImageGradient = document.getElementById('status-pet-image-gradient');
 
     // Verificar se todos os elementos estão disponíveis
-    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusKadirPoints || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText) {
+    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusKadirPoints || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText || !xpBarFill || !xpText || !specieText || !elementText) {
         console.error('Um ou mais elementos do status-container ou title-bar não encontrados', {
             healthContainer: !!healthContainer,
             hungerContainer: !!hungerContainer,
@@ -123,7 +133,11 @@ function updateStatus() {
             statusBioImage: !!statusBioImage,
             titleBarElement: !!titleBarElement,
             titleBarPetName: !!titleBarPetName,
-            statusPetImageGradient: !!statusPetImageGradient
+            statusPetImageGradient: !!statusPetImageGradient,
+            xpBarFill: !!xpBarFill,
+            xpText: !!xpText,
+            specieText: !!specieText,
+            elementText: !!elementText
         });
         return;
     }
@@ -205,6 +219,19 @@ function updateStatus() {
     // Atualizar bio
     if (bioText) {
         bioText.textContent = pet.bio || '';
+    }
+
+    if (xpBarFill && xpText) {
+        const requiredXp = getRequiredXpForNextLevel(pet.level || 1);
+        const percentage = Math.min((pet.experience || 0) / requiredXp * 100, 100);
+        xpBarFill.style.width = `${percentage}%`;
+        xpText.textContent = `${pet.experience || 0}/${requiredXp}`;
+    }
+    if (specieText) {
+        specieText.textContent = `Espécie: ${pet.specie || 'Desconhecida'}`;
+    }
+    if (elementText) {
+        elementText.textContent = `Elemento: ${pet.element || 'Desconhecido'}`;
     }
 
     const healthPercentage = (pet.currentHealth || 0) / (pet.maxHealth || 1) * 100;

--- a/status.html
+++ b/status.html
@@ -377,6 +377,19 @@
             gap: 10px;
         }
 
+        #bio-container {
+            max-height: 157px;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 5px;
+        }
+
+        #xp-bar-fill {
+            background-color: #32cd32;
+        }
+
         #status-moves {
             display: grid;
             grid-template-columns: repeat(2, 1fr);
@@ -526,7 +539,18 @@
                         <div id="move-description"></div>
                     </div>
                     <div id="tab-sobre" class="tab-content-item">
-                        <p id="bio-text" style="text-align:center;"></p>
+                        <div id="bio-container" class="scroll-container">
+                            <div id="xp-bar-container" class="status-item" style="background: none;">
+                                <label>XP</label>
+                                <div class="status-bar">
+                                    <div id="xp-bar-fill" class="status-bar-fill"></div>
+                                </div>
+                                <div id="xp-text">0/0</div>
+                            </div>
+                            <div id="specie-text"></div>
+                            <div id="element-text"></div>
+                            <p id="bio-text" style="text-align:center;"></p>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- show XP progress, species, element and bio in the About tab
- update status page styles for scrolling and XP bar
- compute XP progress in status.js

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856b2d5d19c832ab36c5b634d697cff