### PR TITLE
Adjust meat item benefits

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -10,8 +10,8 @@
     "id": "meat",
     "name": "Carne",
     "icon": "Assets/Shop/meat1.png",
-    "description": "Sacia 20 pontos de fome.",
-    "effect": "Sacia 20 pontos de fome."
+    "description": "Sacia 20 pontos de fome e 10 de felicidade. Recupera 5% da vida.",
+    "effect": "Sacia 20 pontos de fome e 10 de felicidade. Recupera 5% da vida."
   },
   {
     "id": "staminaPotion",

--- a/main.js
+++ b/main.js
@@ -738,6 +738,9 @@ ipcMain.on('use-item', async (event, item) => {
             break;
         case 'meat':
             currentPet.hunger = Math.min((currentPet.hunger || 0) + 20, 100);
+            currentPet.happiness = Math.min((currentPet.happiness || 0) + 10, 100);
+            const healAmount = Math.round(currentPet.maxHealth * 0.05);
+            currentPet.currentHealth = Math.min(currentPet.currentHealth + healAmount, currentPet.maxHealth);
             break;
         case 'staminaPotion':
             currentPet.energy = Math.min((currentPet.energy || 0) + 20, 100);
@@ -750,6 +753,7 @@ ipcMain.on('use-item', async (event, item) => {
         await petManager.updatePet(currentPet.petId, {
             currentHealth: currentPet.currentHealth,
             hunger: currentPet.hunger,
+            happiness: currentPet.happiness,
             energy: currentPet.energy,
             items: currentPet.items
         });


### PR DESCRIPTION
## Summary
- expand the meat item benefits with hunger, happiness and healing
- persist updated happiness when using items
- refresh meat item description

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856b87e8114832a995f55f9f7f2c675