### PR TITLE
Fix rename modal activation

### DIFF
--- a/status.html
+++ b/status.html
@@ -41,6 +41,7 @@
         #title-bar-pet-name-container {
             display: flex;
             align-items: center;
+            -webkit-app-region: no-drag;
         }
 
         #title-bar-pet-name {
@@ -53,12 +54,14 @@
             text-overflow: ellipsis;
             max-width: 150px;
             cursor: pointer;
+            -webkit-app-region: no-drag;
         }
 
         #edit-pet-name {
             display: none;
             font-size: 12px;
             cursor: pointer;
+            -webkit-app-region: no-drag;
         }
 
         #title-bar-pet-name-container:hover #edit-pet-name {


### PR DESCRIPTION
## Summary
- make title bar pet name clickable by excluding it from draggable region

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6856bcc12aa0832a898a4bf728964824