### PR TITLE
Fix bullet advancement logic in journey mode

### DIFF
--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -238,6 +238,7 @@ function concludeBattle(playerWon) {
     currentTurn = 'ended';
     hideMenus();
     window.electronAPI.send('battle-result', { win: playerWon });
+    localStorage.setItem('journeyBattleWin', playerWon ? '1' : '0');
     if (playerWon) {
         const reward = generateReward();
         window.electronAPI.send('reward-pet', reward);


### PR DESCRIPTION
## Summary
- update journey map to record pending advancement when a battle starts
- only advance to the next map bullet if the last battle was won
- store battle result in `journey-scene.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857307d9e58832a8e4522b88617b0ac