### PR TITLE
Implement kadirfull cheat

### DIFF
--- a/main.js
+++ b/main.js
@@ -795,6 +795,28 @@ ipcMain.on('update-health', async (event, newHealth) => {
     }
 });
 
+ipcMain.on('kadirfull', async () => {
+    if (!currentPet) return;
+    currentPet.currentHealth = currentPet.maxHealth;
+    currentPet.hunger = 100;
+    currentPet.happiness = 100;
+    currentPet.energy = 100;
+
+    try {
+        await petManager.updatePet(currentPet.petId, {
+            currentHealth: currentPet.currentHealth,
+            hunger: currentPet.hunger,
+            happiness: currentPet.happiness,
+            energy: currentPet.energy
+        });
+        BrowserWindow.getAllWindows().forEach(w => {
+            if (w.webContents) w.webContents.send('pet-data', currentPet);
+        });
+    } catch (err) {
+        console.error('Erro ao aplicar kadirfull:', err);
+    }
+});
+
 ipcMain.on('reward-pet', async (event, reward) => {
     if (!currentPet || !reward) return;
     if (reward.item) {

--- a/preload.js
+++ b/preload.js
@@ -32,6 +32,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'reward-pet',
             'use-move',
             'update-health',
+            'kadirfull',
             'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
             'close-start-window'  // Fechar a janela de start

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -32,6 +32,17 @@ function hideDescription() {
 
 let renameModal = null;
 let renameInput = null;
+let cheatBuffer = '';
+
+function activateKadirFull() {
+    if (!pet || !pet.petId) return;
+    pet.currentHealth = pet.maxHealth;
+    pet.hunger = 100;
+    pet.happiness = 100;
+    pet.energy = 100;
+    updateStatus();
+    window.electronAPI.send('kadirfull');
+}
 
 function openRenameModal() {
     if (!renameModal || !renameInput || !pet || !pet.petId) return;
@@ -387,6 +398,18 @@ document.addEventListener('DOMContentLoaded', () => {
     } else {
         console.warn('train-moves-button element not found');
     }
+
+    document.addEventListener('keydown', (e) => {
+        const key = e.key.toLowerCase();
+        if (key.length === 1 && /[a-z0-9]/.test(key)) {
+            cheatBuffer += key;
+            if (cheatBuffer.length > 9) cheatBuffer = cheatBuffer.slice(-9);
+            if (cheatBuffer === 'kadirfull') {
+                cheatBuffer = '';
+                activateKadirFull();
+            }
+        }
+    });
 
     // Registrar o listener para o evento pet-data dentro do DOMContentLoaded
     window.electronAPI.on('pet-data', (event, petData) => {


### PR DESCRIPTION
## Summary
- add `kadirfull` IPC channel for cheats
- handle `kadirfull` in main process to refill pet stats
- listen for the key sequence `kadirfull` on status page and trigger the cheat

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6857338159f8832aadc35e4fc5ab21aa