### PR TITLE
Limit number of pets and warn when limit reached

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -198,6 +198,35 @@
             justify-content: center;
             gap: 10px;
         }
+
+        /* Modal de limite de pets */
+        #limit-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            justify-content: center;
+            align-items: center;
+            z-index: 50;
+        }
+
+        #limit-box {
+            background-color: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 20px;
+            text-align: center;
+            font-family: 'PixelOperator', sans-serif;
+        }
+
+        #limit-box .confirm-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
     </style>
 </head>
 
@@ -220,6 +249,15 @@
         </div>
     </div>
 
+    <div id="limit-overlay">
+        <div id="limit-box">
+            <p>Você atingiu o limite de 10 pets. Exclua um pet para criar outro.</p>
+            <div class="confirm-buttons">
+                <button class="button small-button" id="limit-ok">OK</button>
+            </div>
+        </div>
+    </div>
+
     <script type="module">
         import { rarityGradients } from './scripts/constants.js';
 
@@ -227,6 +265,8 @@
         const deleteMessage = document.getElementById('delete-confirm-message');
         const confirmDeleteBtn = document.getElementById('delete-confirm-yes');
         const cancelDeleteBtn = document.getElementById('delete-confirm-no');
+        const limitOverlay = document.getElementById('limit-overlay');
+        const limitOkBtn = document.getElementById('limit-ok');
         let petIdToDelete = null;
         // Função para formatar a data
         function formatDate(isoString) {
@@ -256,6 +296,13 @@
             const petList = document.getElementById('pet-list');
             petList.innerHTML = ''; // Limpar a lista atual
             window.electronAPI.listPets().then(pets => {
+                if (limitOverlay) {
+                    if (pets.length >= 10) {
+                        limitOverlay.style.display = 'flex';
+                    } else {
+                        limitOverlay.style.display = 'none';
+                    }
+                }
                 pets.forEach(pet => {
                     const petItem = document.createElement('div');
                     petItem.className = 'pet-item';
@@ -311,6 +358,10 @@
                     petIdToDelete = null;
                 });
             }
+        });
+
+        limitOkBtn?.addEventListener('click', () => {
+            if (limitOverlay) limitOverlay.style.display = 'none';
         });
 
         // Cancelar exclusão

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -286,7 +286,11 @@ function showNameSelection(element) {
         // Lidar com erro de criação
         window.electronAPI.on('create-pet-error', (event, error) => {
             console.error('Erro ao criar o pet:', error);
-            alert('Erro ao criar o pet. Tente novamente.');
+            if (typeof error === 'string' && error.includes('Limite de 10 pets')) {
+                alert('Você já possui 10 pets. Exclua um pet para criar outro.');
+            } else {
+                alert('Erro ao criar o pet. Tente novamente.');
+            }
             document.getElementById('create-pet-button').disabled = false;
             document.getElementById('name-selection').style.display = 'block';
         });

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -77,6 +77,13 @@ async function createPet(petData) {
     await ensurePetsDir();
     await loadPetCounter();
 
+    // Verificar limite máximo de pets (10)
+    const files = await fs.readdir(petsDir);
+    const petFiles = files.filter(file => file.startsWith('pet_') && file.endsWith('.json'));
+    if (petFiles.length >= 10) {
+        throw new Error('Limite de 10 pets atingido');
+    }
+
     petCounter++;
     const petId = petCounter.toString().padStart(6, '0');
     const petFileName = `pet_${petId}.json`;

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -64,14 +64,29 @@ if (backgroundMusic && muteButton) {
 }
 
 // Eventos dos botões
+const limitOverlay = document.getElementById('limit-overlay');
+const limitOkBtn = document.getElementById('limit-ok');
+
 document.getElementById('start-button').addEventListener('click', () => {
     console.log('Botão Iniciar clicado');
     if (window.electronAPI) {
-        console.log('Enviando open-create-pet-window');
-        window.electronAPI.send('open-create-pet-window');
+        window.electronAPI.listPets().then(pets => {
+            if (pets.length >= 10) {
+                if (limitOverlay) limitOverlay.style.display = 'flex';
+            } else {
+                console.log('Enviando open-create-pet-window');
+                window.electronAPI.send('open-create-pet-window');
+            }
+        }).catch(err => {
+            console.error('Erro ao listar pets:', err);
+        });
     } else {
         console.error('electronAPI não está disponível para enviar open-create-pet-window');
     }
+});
+
+limitOkBtn?.addEventListener('click', () => {
+    if (limitOverlay) limitOverlay.style.display = 'none';
 });
 
 document.getElementById('load-button').addEventListener('click', () => {

--- a/start.html
+++ b/start.html
@@ -115,6 +115,35 @@
             justify-content: center;
             gap: 10px;
         }
+
+        /* Modal de limite de pets */
+        #limit-overlay {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0, 0, 0, 0.7);
+            justify-content: center;
+            align-items: center;
+            z-index: 50;
+        }
+
+        #limit-box {
+            background-color: #2a323e;
+            border: 2px solid #ffffff;
+            border-radius: 7px;
+            padding: 20px;
+            text-align: center;
+            font-family: 'PixelOperator', sans-serif;
+        }
+
+        #limit-box .confirm-buttons {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
     </style>
 </head>
 
@@ -139,6 +168,15 @@
             <div class="confirm-buttons">
                 <button class="button small-button" id="exit-confirm-yes">Sair</button>
                 <button class="button small-button" id="exit-confirm-no">Cancelar</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="limit-overlay">
+        <div id="limit-box">
+            <p>Você atingiu o limite de 10 pets. Exclua um pet para criar outro.</p>
+            <div class="confirm-buttons">
+                <button class="button small-button" id="limit-ok">OK</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- enforce a maximum of 10 pets in `petManager`
- display a modal on the start screen when trying to create a pet beyond the limit
- show the same warning on the load screen
- handle limit error in pet creation flow

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859c86e43ac832ab898c92b9325963d