### PR TITLE
Fix pen canvas display in load pet screen

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -25,6 +25,7 @@
             height: 100%;
             display: flex;
             gap: 10px;
+            align-items: flex-start;
         }
 
         .pet-list {
@@ -36,6 +37,9 @@
 
         #pen-canvas {
             image-rendering: pixelated;
+            max-width: 45%;
+            height: auto;
+            flex-shrink: 0;
         }
 
         .pet-item {


### PR DESCRIPTION
## Summary
- ensure the pen canvas fits beside the pet list

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859e6ea46c4832a9bcf6a4ae9898823