### PR TITLE
Add pen viewer window

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -252,7 +252,8 @@
             <div class="list-pen-wrapper">
                 <div class="pet-list" id="pet-list"></div>
                 <canvas id="pen-canvas" width="192" height="160"></canvas>
-            </div>
+</div>
+            <button class="button" id="show-pen-button">Exibir Pets</button>
             <button class="button" id="back-button">Voltar</button>
         </div>
     </div>
@@ -435,6 +436,10 @@
         cancelDeleteBtn.addEventListener('click', () => {
             deleteOverlay.style.display = 'none';
             petIdToDelete = null;
+        });
+
+        document.getElementById("show-pen-button").addEventListener("click", () => {
+            window.electronAPI.send("open-pen-window");
         });
 
         // Voltar para a janela inicial

--- a/main.js
+++ b/main.js
@@ -99,14 +99,31 @@ ipcMain.on('open-load-pet-window', () => {
     windowManager.createLoadPetWindow();
 });
 
+ipcMain.on("open-pen-window", () => {
+    console.log("Recebido open-pen-window");
+    const penWin = windowManager.createPenWindow();
+    const loadWin = windowManager.loadPetWindow;
+    if (penWin && loadWin) {
+        windowManager.centerWindowsSideBySide(loadWin, penWin);
+    } else if (penWin) {
+        windowManager.centerWindow(penWin);
+    }
+});
+
 ipcMain.on('close-create-pet-window', () => {
     console.log('Recebido close-create-pet-window');
     windowManager.closeCreatePetWindow();
 });
 
-ipcMain.on('close-load-pet-window', () => {
-    console.log('Recebido close-load-pet-window');
+ipcMain.on("close-load-pet-window", () => {
+    console.log("Recebido close-load-pet-window");
     windowManager.closeLoadPetWindow();
+    windowManager.closePenWindow();
+});
+
+ipcMain.on("close-pen-window", () => {
+    console.log("Recebido close-pen-window");
+    windowManager.closePenWindow();
 });
 
 ipcMain.on('close-start-window', () => {

--- a/pen.html
+++ b/pen.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Cercado</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        html, body {
+            width: 100%;
+            height: 100%;
+            margin: 0;
+        }
+        .pen-container {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="pen-container">
+        <canvas id="pen-canvas" width="192" height="160"></canvas>
+    </div>
+    <script type="module" src="scripts/pen.js"></script>
+</body>
+</html>

--- a/preload.js
+++ b/preload.js
@@ -9,6 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'exit-app',
             'open-create-pet-window',
             'open-load-pet-window',
+            'open-pen-window',
+            'close-pen-window',
             'close-create-pet-window',
             'close-load-pet-window',
             'create-pet',

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -1,0 +1,65 @@
+const penCanvas = document.getElementById('pen-canvas');
+const penCtx = penCanvas ? penCanvas.getContext('2d') : null;
+const tileset = new Image();
+tileset.src = 'assets/tileset/tileset.png';
+let penInfo = { size: 'small', maxPets: 3 };
+const sizeMap = { small: { w: 4, h: 3 }, medium: { w: 5, h: 4 }, large: { w: 7, h: 5 } };
+
+function drawPen() {
+    if (!penCtx || !tileset.complete) return;
+    const dims = sizeMap[penInfo.size] || sizeMap.small;
+    const w = (dims.w + 2) * 32;
+    const h = (dims.h + 2) * 32;
+    penCanvas.width = w;
+    penCanvas.height = h;
+    penCtx.clearRect(0,0,w,h);
+    for (let y=0; y<dims.h+2; y++) {
+        for (let x=0; x<dims.w+2; x++) {
+            let sx=32, sy=32;
+            if (x===0 && y===0) { sx=0; sy=0; }
+            else if (x===dims.w+1 && y===0) { sx=64; sy=0; }
+            else if (x===0 && y===dims.h+1) { sx=0; sy=64; }
+            else if (x===dims.w+1 && y===dims.h+1) { sx=64; sy=64; }
+            else if (y===0) { sx=32; sy=0; }
+            else if (y===dims.h+1) { sx=32; sy=64; }
+            else if (x===0) { sx=0; sy=32; }
+            else if (x===dims.w+1) { sx=64; sy=32; }
+            penCtx.drawImage(tileset, sx, sy, 32, 32, x*32, y*32, 32, 32);
+        }
+    }
+}
+
+tileset.onload = drawPen;
+
+function drawPets(pets) {
+    if (!penCtx) return;
+    const dims = sizeMap[penInfo.size] || sizeMap.small;
+    pets.forEach((pet, idx) => {
+        const img = new Image();
+        const src = pet.statusImage ? `Assets/Mons/${pet.statusImage}` : (pet.image ? `Assets/Mons/${pet.image}` : 'Assets/Mons/eggsy.png');
+        img.src = src;
+        img.onload = () => {
+            const col = idx % dims.w;
+            const row = Math.floor(idx / dims.w);
+            const x = (col + 1) * 32;
+            const y = (row + 1) * 32;
+            penCtx.drawImage(img, x, y, 32, 32);
+        };
+    });
+}
+
+function loadPen() {
+    if (window.electronAPI && window.electronAPI.getPenInfo && window.electronAPI.listPets) {
+        Promise.all([
+            window.electronAPI.getPenInfo(),
+            window.electronAPI.listPets()
+        ]).then(([info, pets]) => {
+            penInfo = info;
+            drawPen();
+            drawPets(pets);
+        });
+    }
+}
+
+window.electronAPI?.on('pen-updated', () => loadPen());
+window.addEventListener('DOMContentLoaded', loadPen);

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -86,6 +86,19 @@ function centerWindowAnimated(win) {
     const targetY = Math.round((screenHeight - bounds.height) / 2);
     animateMove(win, targetX, targetY);
 }
+function centerSideBySide(winLeft, winRight) {
+    if (!winLeft || !winRight) return;
+    const display = screen.getPrimaryDisplay();
+    const { width: screenWidth, height: screenHeight } = display.workAreaSize;
+    const b1 = winLeft.getBounds();
+    const b2 = winRight.getBounds();
+    const totalW = b1.width + b2.width;
+    const startX = Math.round((screenWidth - totalW) / 2);
+    const startY = Math.round((screenHeight - Math.max(b1.height, b2.height)) / 2);
+    animateMove(winLeft, startX, startY);
+    animateMove(winRight, startX + b1.width, startY);
+}
+
 
 class WindowManager {
     constructor() {
@@ -94,6 +107,7 @@ class WindowManager {
         this.loadPetWindow = null;
         this.trayWindow = null;
         this.statusWindow = null;
+        this.penWindow = null;
     }
 
     attachFadeHandlers(win) {
@@ -102,6 +116,10 @@ class WindowManager {
 
     centerWindow(win) {
         centerWindowAnimated(win);
+    }
+
+    centerWindowsSideBySide(winLeft, winRight) {
+        centerSideBySide(winLeft, winRight);
     }
 
     // Criar a janela inicial (start.html)
@@ -309,6 +327,44 @@ class WindowManager {
 
         return this.statusWindow;
     }
+    // Criar a janela do cercado (pen.html)
+    createPenWindow() {
+        if (this.penWindow) {
+            this.penWindow.focus();
+            return this.penWindow;
+        }
+
+        const preloadPath = path.join(__dirname, "..", "preload.js");
+        this.penWindow = new BrowserWindow({
+            width: 300,
+            height: 300,
+            frame: false,
+            transparent: true,
+            resizable: false,
+            show: false,
+            webPreferences: {
+                preload: preloadPath,
+                nodeIntegration: false,
+                contextIsolation: true,
+            },
+        });
+
+        this.penWindow.loadFile("pen.html");
+        attachFadeHandlers(this.penWindow);
+        this.penWindow.on("closed", () => {
+            this.penWindow = null;
+        });
+
+        return this.penWindow;
+    }
+
+    // Fechar a penWindow
+    closePenWindow() {
+        if (this.penWindow) {
+            this.penWindow.close();
+        }
+    }
+
 
     // Fechar a statusWindow
     closeStatusWindow() {


### PR DESCRIPTION
## Summary
- implement new `pen.html` window with `pen.js`
- expose new pen window channels in `preload.js`
- support centering two windows side-by-side in `windowManager`
- add creation/close handlers for the pen window in `main.js`
- allow opening the pen viewer from `load-pet.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859e965df3c832a885cef3ac10ced02