### PR TITLE
Add border and back button to pen window

### DIFF
--- a/pen.html
+++ b/pen.html
@@ -12,6 +12,7 @@
             margin: 0;
         }
         .pen-container {
+            position: relative;
             width: 100%;
             height: 100%;
             display: flex;
@@ -20,15 +21,38 @@
             margin: 5px;
         }
 
+        #back-pen-window {
+            position: absolute;
+            top: 0;
+            left: 0;
+            margin: 5px;
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
+
         #pen-canvas {
             image-rendering: pixelated;
-            transform: scale(1.2);
+            transform: scale(1.5);
             transform-origin: top left;
+            border-radius: 12px;
+            border: 2px solid #ffffff;
         }
     </style>
 </head>
 <body>
     <div class="pen-container">
+        <div id="back-pen-window">↩</div>
         <canvas id="pen-canvas" width="192" height="160"></canvas>
     </div>
     <script type="module" src="scripts/pen.js"></script>

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -62,4 +62,9 @@ function loadPen() {
 }
 
 window.electronAPI?.on('pen-updated', () => loadPen());
-window.addEventListener('DOMContentLoaded', loadPen);
+window.addEventListener('DOMContentLoaded', () => {
+    loadPen();
+    document.getElementById('back-pen-window')?.addEventListener('click', () => {
+        window.electronAPI?.send('close-pen-window');
+    });
+});


### PR DESCRIPTION
## Summary
- add back button to pen canvas window
- update pen canvas styling with scale, border and radius
- close pen window via new back button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859f275c124832abc2de0b05c3d61e5