### PR TITLE
Add random pet movement

### DIFF
--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -5,6 +5,11 @@ tileset.src = 'assets/tileset/tileset.png';
 let penInfo = { size: 'small', maxPets: 3 };
 const sizeMap = { small: { w: 4, h: 3 }, medium: { w: 5, h: 4 }, large: { w: 7, h: 5 } };
 
+let sprites = [];
+let lastTime = 0;
+let animationId = null;
+const MOVE_SPEED = 16; // pixels per second
+
 function drawPen() {
     if (!penCtx || !tileset.complete) return;
     const dims = sizeMap[penInfo.size] || sizeMap.small;
@@ -31,21 +36,71 @@ function drawPen() {
 
 tileset.onload = drawPen;
 
+function updateSprites(dt) {
+    const dims = sizeMap[penInfo.size] || sizeMap.small;
+    sprites.forEach(sp => {
+        if (sp.pause > 0) {
+            sp.pause -= dt;
+            return;
+        }
+        if (!sp.moving) {
+            const col = Math.floor(Math.random() * dims.w);
+            const row = Math.floor(Math.random() * dims.h);
+            sp.targetX = (col + 1) * 32;
+            sp.targetY = (row + 1) * 32;
+            sp.moving = true;
+        }
+
+        const dx = sp.targetX - sp.x;
+        const dy = sp.targetY - sp.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
+        const step = MOVE_SPEED * dt;
+        if (dist <= step) {
+            sp.x = sp.targetX;
+            sp.y = sp.targetY;
+            sp.moving = false;
+            sp.pause = Math.random() * 2 + 0.5;
+        } else {
+            sp.x += (dx / dist) * step;
+            sp.y += (dy / dist) * step;
+        }
+    });
+}
+
+function render() {
+    if (!penCtx) return;
+    drawPen();
+    sprites.forEach(sp => {
+        if (sp.img.complete)
+            penCtx.drawImage(sp.img, sp.x, sp.y, 32, 32);
+    });
+}
+
+function animate(timestamp) {
+    const dt = (timestamp - lastTime) / 1000;
+    lastTime = timestamp;
+    updateSprites(dt);
+    render();
+    animationId = requestAnimationFrame(animate);
+}
+
 function drawPets(pets) {
     if (!penCtx) return;
     const dims = sizeMap[penInfo.size] || sizeMap.small;
-    pets.forEach((pet, idx) => {
+    sprites = [];
+    if (animationId) cancelAnimationFrame(animationId);
+    pets.forEach((pet) => {
         const img = new Image();
         const src = pet.statusImage ? `Assets/Mons/${pet.statusImage}` : (pet.image ? `Assets/Mons/${pet.image}` : 'Assets/Mons/eggsy.png');
         img.src = src;
-        img.onload = () => {
-            const col = idx % dims.w;
-            const row = Math.floor(idx / dims.w);
-            const x = (col + 1) * 32;
-            const y = (row + 1) * 32;
-            penCtx.drawImage(img, x, y, 32, 32);
-        };
+        const col = Math.floor(Math.random() * dims.w);
+        const row = Math.floor(Math.random() * dims.h);
+        const x = (col + 1) * 32;
+        const y = (row + 1) * 32;
+        sprites.push({ img, x, y, targetX: x, targetY: y, moving: false, pause: Math.random() * 2 });
     });
+    lastTime = performance.now();
+    animationId = requestAnimationFrame(animate);
 }
 
 function loadPen() {


### PR DESCRIPTION
## Summary
- animate pets in the pen with slow randomized wandering

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859f61f0984832ab64e84113a54557c