### PR TITLE
Increase load pet window height

### DIFF
--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -213,7 +213,7 @@ class WindowManager {
         const preloadPath = path.join(__dirname, '..', 'preload.js');
         this.loadPetWindow = new BrowserWindow({
             width: 600,
-            height: 400,
+            height: 600,
             frame: false,
             transparent: true,
             resizable: false,


### PR DESCRIPTION
## Summary
- expand the Load Pet browser window height to ensure bottom buttons are visible

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859f7862d4c832abcd11d7977a9291a