### PR TITLE
Fix load-pet layout

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -243,6 +243,16 @@
             justify-content: center;
             gap: 10px;
         }
+
+        .button-row {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+        }
+
+        .window {
+            height: 430px;
+        }
     </style>
 </head>
 
@@ -253,8 +263,10 @@
             <div class="list-pen-wrapper">
                 <div class="pet-list" id="pet-list"></div>
             </div>
-            <button class="button" id="show-pen-button">Exibir Pets</button>
-            <button class="button" id="back-button">Voltar</button>
+            <div class="button-row">
+                <button class="button" id="show-pen-button">Exibir Pets</button>
+                <button class="button" id="back-button">Voltar</button>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary
- make the show pen and back buttons appear side by side
- set a fixed window height for the load pet screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859f8e4d42c832a9e50397320d61d31