### PR TITLE
Update load-pet styles and window positioning

### DIFF
--- a/main.js
+++ b/main.js
@@ -96,7 +96,13 @@ ipcMain.on('open-load-pet-window', () => {
     console.log('Recebido open-load-pet-window');
     // Não fechar todas as janelas para permitir voltar
     // à tela anterior (start ou index) ao sair da seleção
-    windowManager.createLoadPetWindow();
+    const loadWin = windowManager.createLoadPetWindow();
+    const penWin = windowManager.penWindow;
+    if (loadWin && penWin) {
+        windowManager.centerWindowsSideBySide(loadWin, penWin);
+    } else if (loadWin) {
+        windowManager.centerWindow(loadWin);
+    }
 });
 
 ipcMain.on("open-pen-window", () => {

--- a/styles/main.css
+++ b/styles/main.css
@@ -70,7 +70,7 @@ img {
     border-radius: 7px;
     padding: 8px 16px; /* Reduzir o padding dos botões */
     margin: 5px; /* Reduzir o margin para ajustar ao espaço */
-    font-size: 18px; /* Reduzir o tamanho da fonte */
+    font-size: 14px; /* Tamanho de fonte padronizado */
     color: #ffffff;
     text-shadow: 1px 1px 2px black, -1px -1px 2px black, 1px -1px 2px black, -1px 1px 2px black;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- tweak global button CSS to use 14px font
- when opening the load pet window, align it with any open pen window so both appear side by side

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859fa80350c832a96d91479a72ed140