### PR TITLE
Display pet thumbnail on journey map

### DIFF
--- a/journey-mode.html
+++ b/journey-mode.html
@@ -55,6 +55,15 @@
             border: 2px solid #fff;
         }
 
+        #pet-thumbnail {
+            position: absolute;
+            width: 32px;
+            height: 32px;
+            image-rendering: pixelated;
+            pointer-events: none;
+            display: none;
+        }
+
         @keyframes blink {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.3; }
@@ -126,6 +135,7 @@
                 <div class="path-subpoint" style="top: 496px;left: 843px;"></div>
                 <div class="path-subpoint" style="top: 485px;left: 887px;"></div>
 
+                <img id="pet-thumbnail" src="" alt="Pet">
                 <div id="map-tooltip" style="display: none; left: 900px; top: 170px;"><img src="Assets/Modes/Journeys/cave_ruin.png" alt="preview"><div class="tooltip-name"></div></div>
                 <div id="event-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
                     <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">


### PR DESCRIPTION
## Summary
- add styling for new pet thumbnail on the journey map
- insert pet thumbnail element in the map markup
- load pet data in `journey-map.js` and show marker near the current step
- keep marker updated when changing stages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6859fdfc0694832ab2b1df3dc4148b47