### PR TITLE
Set load-pet window max height to 430px

### DIFF
--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -213,7 +213,7 @@ class WindowManager {
         const preloadPath = path.join(__dirname, '..', 'preload.js');
         this.loadPetWindow = new BrowserWindow({
             width: 600,
-            height: 600,
+            height: 430,
             frame: false,
             transparent: true,
             resizable: false,


### PR DESCRIPTION
## Summary
- resize load-pet window in the window manager so it does not exceed 430px in height

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685a0055a198832a899d066500204ff5