### PR TITLE
Fix GIF sprites in pen

### DIFF
--- a/pen.html
+++ b/pen.html
@@ -11,6 +11,24 @@
             height: 100%;
             margin: 0;
         }
+
+        #pets-layer {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            transform: scale(1.5);
+            transform-origin: top left;
+            pointer-events: none;
+        }
+
+        .pet-sprite {
+            position: absolute;
+            width: 32px;
+            height: 32px;
+            image-rendering: pixelated;
+        }
         .pen-container {
             position: relative;
             width: 100%;
@@ -55,6 +73,7 @@
     <div class="pen-container">
         <div id="back-pen-window">↩</div>
         <canvas id="pen-canvas" width="192" height="160"></canvas>
+        <div id="pets-layer"></div>
     </div>
     <script type="module" src="scripts/pen.js"></script>
 </body>

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -1,4 +1,5 @@
 const penCanvas = document.getElementById('pen-canvas');
+const petsLayer = document.getElementById('pets-layer');
 const penCtx = penCanvas ? penCanvas.getContext('2d') : null;
 const tileset = new Image();
 tileset.src = 'assets/tileset/tileset.png';
@@ -71,8 +72,8 @@ function render() {
     if (!penCtx) return;
     drawPen();
     sprites.forEach(sp => {
-        if (sp.img.complete)
-            penCtx.drawImage(sp.img, sp.x, sp.y, 32, 32);
+        sp.img.style.left = sp.x + 'px';
+        sp.img.style.top = sp.y + 'px';
     });
 }
 
@@ -85,16 +86,19 @@ function animate(timestamp) {
 }
 
 function drawPets(pets) {
-    if (!penCtx) return;
+    if (!penCtx || !petsLayer) return;
     const dims = sizeMap[penInfo.size] || sizeMap.small;
     sprites = [];
+    petsLayer.innerHTML = '';
     if (animationId) cancelAnimationFrame(animationId);
     pets.forEach((pet) => {
-        const img = new Image();
+        const img = document.createElement('img');
         const src = pet.idleImage ? `Assets/Mons/${pet.idleImage}` :
             (pet.statusImage ? `Assets/Mons/${pet.statusImage}` :
                 (pet.image ? `Assets/Mons/${pet.image}` : 'Assets/Mons/eggsy.png'));
         img.src = src;
+        img.className = 'pet-sprite';
+        petsLayer.appendChild(img);
         const col = Math.floor(Math.random() * dims.w);
         const row = Math.floor(Math.random() * dims.h);
         const x = (col + 1) * 32;


### PR DESCRIPTION
## Summary
- overlay pets as `<img>` elements so their GIF animations play normally
- add a DOM layer for pets in `pen.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b2694afb8832ab05a6533eb1d735e