### PR TITLE
Restrict new pet creation after first pet

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -66,14 +66,9 @@ if (backgroundMusic && muteButton) {
 // Eventos dos botões
 const limitOverlay = document.getElementById('limit-overlay');
 const limitOkBtn = document.getElementById('limit-ok');
-let petLimit = 3;
-if (window.electronAPI && window.electronAPI.getPenInfo) {
-    window.electronAPI.getPenInfo().then(info => {
-        petLimit = info.maxPets;
-        const msg = document.getElementById('limit-message');
-        if (msg) msg.textContent = `Você atingiu o limite de ${petLimit} pets. Exclua um pet para criar outro.`;
-    });
-}
+const petLimit = 1;
+const msg = document.getElementById('limit-message');
+if (msg) msg.textContent = 'Você já possui um pet. Exclua-o para criar outro.';
 
 document.getElementById('start-button').addEventListener('click', () => {
     console.log('Botão Iniciar clicado');

--- a/start.html
+++ b/start.html
@@ -174,7 +174,7 @@
 
     <div id="limit-overlay">
         <div id="limit-box">
-            <p id="limit-message">Você atingiu o limite de 3 pets. Exclua um pet para criar outro.</p>
+            <p id="limit-message">Você já possui um pet. Exclua-o para criar outro.</p>
             <div class="confirm-buttons">
                 <button class="button small-button" id="limit-ok">OK</button>
             </div>


### PR DESCRIPTION
## Summary
- prevent creating additional pets from the start screen
- update limit message in start page

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_685b2dbcfad4832a9cddb1faef67c964