### PR TITLE
Handle deletion of last pet

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -433,9 +433,16 @@
         confirmDeleteBtn.addEventListener('click', () => {
             if (petIdToDelete !== null) {
                 window.electronAPI.deletePet(petIdToDelete).then(() => {
-                    reloadPetList();
-                    deleteOverlay.style.display = 'none';
-                    petIdToDelete = null;
+                    window.electronAPI.listPets().then(pets => {
+                        deleteOverlay.style.display = 'none';
+                        petIdToDelete = null;
+                        if (pets.length === 0) {
+                            window.electronAPI.send('close-load-pet-window');
+                            window.electronAPI.openStartWindow();
+                        } else {
+                            reloadPetList();
+                        }
+                    });
                 });
             }
         });

--- a/main.js
+++ b/main.js
@@ -137,6 +137,11 @@ ipcMain.on('close-start-window', () => {
     windowManager.closeStartWindow();
 });
 
+ipcMain.on('open-start-window', () => {
+    console.log('Recebido open-start-window');
+    windowManager.createStartWindow();
+});
+
 ipcMain.on('create-pet', async (event, petData) => {
     console.log('Recebido create-pet com dados:', petData);
     try {

--- a/preload.js
+++ b/preload.js
@@ -37,7 +37,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'kadirfull',
             'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
-            'close-start-window'  // Fechar a janela de start
+            'close-start-window',  // Fechar a janela de start
+            'open-start-window'   // Abrir a janela de start
         ];
         if (validChannels.includes(channel)) {
             console.log(`Enviando canal IPC: ${channel}`, data);
@@ -91,6 +92,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     closeCreatePetWindow: () => {
         console.log('Enviando close-create-pet-window');
         ipcRenderer.send('close-create-pet-window');
+    },
+    openStartWindow: () => {
+        console.log('Enviando open-start-window');
+        ipcRenderer.send('open-start-window');
     },
     getMuteState: () => {
         console.log('Enviando get-mute-state');


### PR DESCRIPTION
## Summary
- add a new IPC channel for opening the start window
- expose `openStartWindow` in `preload.js`
- after deleting the last pet redirect back to `start.html`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_e_685b3087663c832a8468f725d9e4ccf2