### PR TITLE
Add cheat code support for items

### DIFF
--- a/scripts/items.js
+++ b/scripts/items.js
@@ -1,6 +1,7 @@
 let pet = null;
 let itemsInfo = {};
 let descriptionEl = null;
+let cheatBuffer = '';
 
 function showDescription(text, evt) {
     if (!descriptionEl) return;
@@ -39,6 +40,18 @@ document.addEventListener('DOMContentLoaded', () => {
         const countEl = document.getElementById('coin-count');
         if (countEl) countEl.textContent = pet.coins ?? 0;
         updateItems();
+    });
+
+    document.addEventListener('keydown', (e) => {
+        const key = e.key.toLowerCase();
+        if (key.length === 1 && /[a-z0-9]/.test(key)) {
+            cheatBuffer += key;
+            if (cheatBuffer.length > 7) cheatBuffer = cheatBuffer.slice(-7);
+            if (cheatBuffer === 'kadir11') {
+                cheatBuffer = '';
+                window.electronAPI.send('reward-pet', { coins: 100, kadirPoints: 100 });
+            }
+        }
     });
 });
 


### PR DESCRIPTION
## Summary
- add `cheatBuffer` and a `kadir11` cheat in `items.js`
- typing `kadir11` in the items window grants 100 coins and 100 Kadir Points

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bd7cc6788832ab198e0a96c9505b3