### PR TITLE
Improve pen window sizing

### DIFF
--- a/pen.html
+++ b/pen.html
@@ -92,12 +92,14 @@
     </style>
 </head>
 <body>
-    <div class="pen-container">
-        <div id="back-pen-window">↩</div>
-        <canvas id="pen-canvas" width="192" height="160"></canvas>
-        <div id="pets-layer"></div>
-        <div class="nests-row">
-            <div id="nests-container"></div>
+    <div class="window">
+        <div class="pen-container">
+            <div id="back-pen-window">↩</div>
+            <canvas id="pen-canvas" width="192" height="160"></canvas>
+            <div id="pets-layer"></div>
+            <div class="nests-row">
+                <div id="nests-container"></div>
+            </div>
         </div>
     </div>
     <script type="module" src="scripts/pen.js"></script>

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -336,8 +336,8 @@ class WindowManager {
 
         const preloadPath = path.join(__dirname, "..", "preload.js");
         this.penWindow = new BrowserWindow({
-            width: 300,
-            height: 300,
+            width: 350,
+            height: 360,
             frame: false,
             transparent: true,
             resizable: false,


### PR DESCRIPTION
## Summary
- enlarge the pen window in `createPenWindow` so nests don't overlap with the fence
- wrap pen content in the standard `.window` container for default background color

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bddfb89b0832aade1bcbe20cc105d