### PR TITLE
Adjust pen window width dynamically

### DIFF
--- a/main.js
+++ b/main.js
@@ -759,6 +759,13 @@ ipcMain.on('resize-journey-window', (event, size) => {
     }
 });
 
+ipcMain.on('resize-pen-window', (event, data) => {
+    if (windowManager.penWindow && data && data.width) {
+        const [, height] = windowManager.penWindow.getSize();
+        windowManager.penWindow.setSize(Math.round(data.width), height);
+    }
+});
+
 ipcMain.on('buy-item', async (event, item) => {
     if (!currentPet) return;
     const prices = {

--- a/preload.js
+++ b/preload.js
@@ -29,6 +29,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'open-journey-mode-window',
             'open-journey-scene-window',
             'resize-journey-window',
+            'resize-pen-window',
             'set-mute-state',
             'get-journey-images',
             'reward-pet',

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -19,6 +19,8 @@ function drawPen() {
     const h = (dims.h + 2) * 32;
     penCanvas.width = w;
     penCanvas.height = h;
+    const displayWidth = penCanvas.getBoundingClientRect().width;
+    window.electronAPI?.send('resize-pen-window', { width: displayWidth });
     penCtx.clearRect(0,0,w,h);
     for (let y=0; y<dims.h+2; y++) {
         for (let x=0; x<dims.w+2; x++) {


### PR DESCRIPTION
## Summary
- resize `pen.html` window so it matches the canvas width
- expose new `resize-pen-window` IPC channel
- implement IPC handler to resize the window in `main.js`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685be00e24a4832a8e59cff28993eceb