### PR TITLE
Adjust pen window size dynamically

### DIFF
--- a/main.js
+++ b/main.js
@@ -806,10 +806,9 @@ ipcMain.on('resize-journey-window', (event, size) => {
     }
 });
 
-ipcMain.on('resize-pen-window', (event, data) => {
-    if (windowManager.penWindow && data && data.width) {
-        const [, height] = windowManager.penWindow.getSize();
-        windowManager.penWindow.setSize(Math.round(data.width), height);
+ipcMain.on('resize-pen-window', (event, size) => {
+    if (windowManager.penWindow && size && size.width && size.height) {
+        windowManager.penWindow.setSize(Math.round(size.width), Math.round(size.height));
         if (nestsWindow) {
             const bounds = windowManager.penWindow.getBounds();
             nestsWindow.setPosition(bounds.x, bounds.y + bounds.height);

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -19,8 +19,15 @@ function drawPen() {
     const h = (dims.h + 2) * 32;
     penCanvas.width = w;
     penCanvas.height = h;
-    const displayWidth = penCanvas.getBoundingClientRect().width;
-    window.electronAPI?.send('resize-pen-window', { width: displayWidth });
+    const container = document.querySelector('.pen-container');
+    if (container) {
+        const rect = container.getBoundingClientRect();
+        const size = {
+            width: rect.width + 10,
+            height: rect.height + 10
+        };
+        window.electronAPI?.send('resize-pen-window', size);
+    }
     penCtx.clearRect(0,0,w,h);
     for (let y=0; y<dims.h+2; y++) {
         for (let x=0; x<dims.w+2; x++) {


### PR DESCRIPTION
## Summary
- update the pen renderer to calculate pen window size using the canvas container
- resize the Electron pen window using both width and height

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bed1a0450832aabf7535628daef97