### PR TITLE
Fix pen window cropping and alignment

### DIFF
--- a/main.js
+++ b/main.js
@@ -123,7 +123,12 @@ ipcMain.on('open-load-pet-window', () => {
     const loadWin = windowManager.createLoadPetWindow();
     const penWin = windowManager.penWindow;
     if (loadWin && penWin) {
-        windowManager.centerWindowsSideBySide(loadWin, penWin);
+        const lb = loadWin.getBounds();
+        const pb = penWin.getBounds();
+        penWin.setPosition(lb.x - pb.width, lb.y);
+        if (nestsWindow) {
+            nestsWindow.setPosition(lb.x - pb.width, lb.y + pb.height);
+        }
     } else if (loadWin) {
         windowManager.centerWindow(loadWin);
     }
@@ -135,10 +140,11 @@ ipcMain.on("open-pen-window", () => {
     const nestsWin = createNestsWindow();
     const loadWin = windowManager.loadPetWindow;
     if (penWin && loadWin) {
-        windowManager.centerWindowsSideBySide(loadWin, penWin);
+        const lb = loadWin.getBounds();
+        const pb = penWin.getBounds();
+        penWin.setPosition(lb.x - pb.width, lb.y);
         if (nestsWin) {
-            const bounds = penWin.getBounds();
-            nestsWin.setPosition(bounds.x, bounds.y + bounds.height);
+            nestsWin.setPosition(lb.x - pb.width, lb.y + pb.height);
         }
     } else if (penWin && nestsWin) {
         windowManager.centerWindowsVertically(penWin, nestsWin);

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -27,9 +27,10 @@ function drawPen() {
     penCanvas.height = h;
     penCanvas.style.transform = `scale(${scale})`;
     if (petsLayer) petsLayer.style.transform = `scale(${scale})`;
+    const padding = 20;
     const size = {
-        width: Math.round(w * scale) + 10,
-        height: Math.round(h * scale) + 10
+        width: Math.round(w * scale) + padding,
+        height: Math.round(h * scale) + padding
     };
     window.electronAPI?.send('resize-pen-window', size);
     penCtx.clearRect(0,0,w,h);


### PR DESCRIPTION
## Summary
- adjust padding when sizing the pen window so the enclosure isn't cut off
- place the pen window to the upper-left of the pet selection window when both are open

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bfd1e33e4832ab451fc695099bb1e