### PR TITLE
Adjust pen window positioning

### DIFF
--- a/main.js
+++ b/main.js
@@ -125,9 +125,9 @@ ipcMain.on('open-load-pet-window', () => {
     if (loadWin && penWin) {
         const lb = loadWin.getBounds();
         const pb = penWin.getBounds();
-        penWin.setPosition(lb.x - pb.width, lb.y);
+        penWin.setPosition(lb.x + lb.width, lb.y);
         if (nestsWindow) {
-            nestsWindow.setPosition(lb.x - pb.width, lb.y + pb.height);
+            nestsWindow.setPosition(lb.x + lb.width, lb.y + pb.height);
         }
     } else if (loadWin) {
         windowManager.centerWindow(loadWin);
@@ -142,9 +142,9 @@ ipcMain.on("open-pen-window", () => {
     if (penWin && loadWin) {
         const lb = loadWin.getBounds();
         const pb = penWin.getBounds();
-        penWin.setPosition(lb.x - pb.width, lb.y);
+        penWin.setPosition(lb.x + lb.width, lb.y);
         if (nestsWin) {
-            nestsWin.setPosition(lb.x - pb.width, lb.y + pb.height);
+            nestsWin.setPosition(lb.x + lb.width, lb.y + pb.height);
         }
     } else if (penWin && nestsWin) {
         windowManager.centerWindowsVertically(penWin, nestsWin);

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -353,8 +353,8 @@ class WindowManager {
 
         const preloadPath = path.join(__dirname, "..", "preload.js");
         this.penWindow = new BrowserWindow({
-            width: 350,
-            height: 360,
+            width: 370,
+            height: 300,
             frame: false,
             transparent: true,
             resizable: false,


### PR DESCRIPTION
## Summary
- position pen and nests windows to the right of the load-pet window
- enlarge default pen window size to fit the maximum pen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685bff48ae14832ab6f031cc0e0eb7b1