### PR TITLE
Add nest-plus indicator for eggs

### DIFF
--- a/scripts/nests.js
+++ b/scripts/nests.js
@@ -10,6 +10,12 @@ const eggIcons = {
 };
 
 let nestsData = [];
+let pet = null;
+
+function hasEggInInventory() {
+    if (!pet || !pet.items) return false;
+    return Object.keys(pet.items).some(id => id.startsWith('egg') && pet.items[id] > 0);
+}
 
 function drawNests(count) {
     if (!nestsContainer) return;
@@ -18,11 +24,15 @@ function drawNests(count) {
     for (let i = 0; i < n; i++) {
         const slot = document.createElement('div');
         slot.style.position = 'relative';
-        const img = document.createElement('img');
-        img.src = 'Assets/tileset/nest.png';
-        img.className = 'nest-image';
-        slot.appendChild(img);
+        const baseImg = document.createElement('img');
         const egg = nestsData[i];
+        if (egg) {
+            baseImg.src = 'Assets/tileset/nest.png';
+        } else {
+            baseImg.src = hasEggInInventory() ? 'Assets/tileset/nest-plus.png' : 'Assets/tileset/nest.png';
+        }
+        baseImg.className = 'nest-image';
+        slot.appendChild(baseImg);
         if (egg) {
             const eggImg = document.createElement('img');
             eggImg.src = eggIcons[egg.eggId] || '';
@@ -50,6 +60,10 @@ function loadNests() {
 window.electronAPI?.on('nest-updated', (e, count) => drawNests(count));
 window.electronAPI?.on('nests-data-updated', (e, data) => {
     nestsData = Array.isArray(data) ? data : [];
+    loadNests();
+});
+window.electronAPI?.on('pet-data', (event, data) => {
+    pet = data;
     loadNests();
 });
 window.addEventListener('DOMContentLoaded', loadNests);

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -10,6 +10,12 @@ const sizeMap = { small: { w: 4, h: 3 }, medium: { w: 5, h: 4 }, large: { w: 7, 
 let sprites = [];
 let lastTime = 0;
 let animationId = null;
+let pet = null;
+
+function hasEggInInventory() {
+    if (!pet || !pet.items) return false;
+    return Object.keys(pet.items).some(id => id.startsWith('egg') && pet.items[id] > 0);
+}
 const MOVE_SPEED = 16; // pixels per second
 
 function getScale(size) {
@@ -58,7 +64,7 @@ function drawNests(count) {
     const n = Math.min(3, count || 0);
     for (let i = 0; i < n; i++) {
         const img = document.createElement('img');
-        img.src = 'Assets/tileset/nest.png';
+        img.src = hasEggInInventory() ? 'Assets/tileset/nest-plus.png' : 'Assets/tileset/nest.png';
         img.className = 'nest-image';
         nestsContainer.appendChild(img);
     }
@@ -157,6 +163,10 @@ function loadNests() {
 
 window.electronAPI?.on('pen-updated', () => loadPen());
 window.electronAPI?.on('nest-updated', (e, count) => drawNests(count));
+window.electronAPI?.on('pet-data', (event, data) => {
+    pet = data;
+    loadNests();
+});
 window.addEventListener('DOMContentLoaded', () => {
     loadPen();
     loadNests();


### PR DESCRIPTION
## Summary
- update nests window to highlight empty nests when eggs exist in inventory
- update pen to use nest-plus image when player has eggs

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c0618ca88832a9681f073c7dce1bf