### PR TITLE
Centralize coin balance in user store

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -399,7 +399,6 @@
                             <p><strong>Raridade:</strong> ${formatRarity(pet.rarity)}</p>
                             <p><strong>Último Acesso:</strong> ${pet.lastAccessed ? formatDate(pet.lastAccessed) : 'Nunca'}</p>
                             <p><img class="currency-icon" src="assets/icons/dna-kadir.png" alt="KP"> ${pet.kadirPoints ?? 0}</p>
-                            <p><img class="currency-icon" src="assets/icons/kadircoin.png" alt="Moedas"> ${pet.coins ?? 0}</p>
                         </div>
                         <button class="delete-button" data-pet-id="${pet.petId}">
                             <img src="Assets/Icons/trash-can.svg" alt="Delete Icon" style="image-rendering: pixelated;" />

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -109,7 +109,6 @@ async function createPet(petData) {
         hunger: petData.hunger || 100,
         happiness: petData.happiness || 100,
         energy: petData.energy || 100,
-        coins: petData.coins || 20,
         kadirPoints: petData.kadirPoints || 5,
         winStreak: 0,
         lossStreak: 0,
@@ -154,9 +153,6 @@ async function listPets() {
                     if (pet.kadirPoints === undefined) {
                         pet.kadirPoints = 5;
                     }
-                    if (pet.coins === undefined) {
-                        pet.coins = 20;
-                    }
                    if (pet.items === undefined) {
                        pet.items = {};
                    }
@@ -199,9 +195,6 @@ async function loadPet(petId) {
         const pet = JSON.parse(data);
         if (pet.kadirPoints === undefined) {
             pet.kadirPoints = 5;
-        }
-        if (pet.coins === undefined) {
-            pet.coins = 20;
         }
        if (pet.items === undefined) {
            pet.items = {};


### PR DESCRIPTION
## Summary
- keep coin balance in electron-store instead of per pet
- show coins only on items and store pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685c097b4b84832a998f8e43d149038b