### PR TITLE
Add hatch window

### DIFF
--- a/hatch.html
+++ b/hatch.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Chocar Ovo</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        html, body { width:100%; height:100%; margin:0; padding:0; background:transparent; }
+        #hatch-overlay {
+            display: flex;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.8);
+            z-index: 50;
+            justify-content: center;
+            align-items: center;
+            flex-direction: column;
+        }
+        #hatch-name {
+            display: none;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
+        }
+        #hatch-name-input { max-width: 150px; }
+    </style>
+</head>
+<body>
+    <div id="hatch-overlay">
+        <video id="hatch-video" src="Assets/Mons/egg_hatch.mp4" style="width:100%;height:100%;object-fit:contain;"></video>
+        <div id="hatch-name">
+            <img id="hatch-gif" src="" alt="Pet" style="width:128px;height:128px;image-rendering:pixelated;">
+            <div>
+                <input type="text" id="hatch-name-input" placeholder="dê um nome para o seu novo pet!" maxlength="15">
+                <button class="button small-button" id="hatch-ok">OK</button>
+            </div>
+        </div>
+    </div>
+    <script type="module" src="scripts/hatch.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -33,6 +33,7 @@ let storeWindow = null;
 let journeyImagesCache = null;
 let journeySceneWindow = null;
 let nestsWindow = null;
+let hatchWindow = null;
 
 function getCoins() {
     return store.get('coins', 20);
@@ -264,6 +265,16 @@ ipcMain.on("close-pen-window", () => {
     console.log("Recebido close-pen-window");
     windowManager.closePenWindow();
     closeNestsWindow();
+});
+
+ipcMain.on('open-hatch-window', () => {
+    console.log('Recebido open-hatch-window');
+    createHatchWindow();
+});
+
+ipcMain.on('close-hatch-window', () => {
+    console.log('Recebido close-hatch-window');
+    closeHatchWindow();
 });
 
 ipcMain.on('close-start-window', () => {
@@ -825,6 +836,38 @@ function createNestsWindow() {
     return nestsWindow;
 }
 
+function createHatchWindow() {
+    if (hatchWindow) {
+        hatchWindow.show();
+        hatchWindow.focus();
+        return hatchWindow;
+    }
+
+    const preloadPath = require('path').join(__dirname, 'preload.js');
+
+    hatchWindow = new BrowserWindow({
+        width: 350,
+        height: 300,
+        frame: false,
+        transparent: true,
+        resizable: false,
+        show: false,
+        webPreferences: {
+            preload: preloadPath,
+            nodeIntegration: false,
+            contextIsolation: true,
+        },
+    });
+
+    hatchWindow.loadFile('hatch.html');
+    windowManager.attachFadeHandlers(hatchWindow);
+    hatchWindow.on('closed', () => {
+        hatchWindow = null;
+    });
+
+    return hatchWindow;
+}
+
 function closeBattleModeWindow() {
     if (battleModeWindow) {
         battleModeWindow.close();
@@ -867,6 +910,12 @@ function closeNestsWindow() {
     }
 }
 
+function closeHatchWindow() {
+    if (hatchWindow) {
+        hatchWindow.close();
+    }
+}
+
 function closeAllGameWindows() {
     windowManager.closeTrayWindow();
     windowManager.closeStatusWindow();
@@ -879,6 +928,7 @@ function closeAllGameWindows() {
     closeItemsWindow();
     closeStoreWindow();
     closeNestsWindow();
+    closeHatchWindow();
 }
 
 ipcMain.on('open-battle-mode-window', () => {

--- a/nests.html
+++ b/nests.html
@@ -135,16 +135,6 @@
     <div class="window nests-window">
         <div id="nests-container" class="nests-row"></div>
     </div>
-    <div id="hatch-overlay">
-        <video id="hatch-video" src="Assets/Mons/egg_hatch.mp4" style="width:100%;height:100%;object-fit:contain;"></video>
-        <div id="hatch-name">
-            <img id="hatch-gif" src="" alt="Pet" style="width:128px;height:128px;image-rendering:pixelated;">
-            <div>
-                <input type="text" id="hatch-name-input" placeholder="dê um nome para o seu novo pet!" maxlength="15">
-                <button class="button small-button" id="hatch-ok">OK</button>
-            </div>
-        </div>
-    </div>
     <div id="egg-select-overlay">
         <div id="egg-select-box">
             <p>Selecione um ovo para colocar no ninho:</p>

--- a/preload.js
+++ b/preload.js
@@ -36,6 +36,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'journey-complete',
             'place-egg-in-nest',
             'hatch-egg',
+            'open-hatch-window',
+            'close-hatch-window',
             'use-move',
             'update-health',
             'kadirfull',
@@ -130,6 +132,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getNestsData: () => {
         console.log('Enviando get-nests-data');
         return ipcRenderer.invoke('get-nests-data');
+    },
+    openHatchWindow: () => {
+        console.log('Enviando open-hatch-window');
+        ipcRenderer.send('open-hatch-window');
+    },
+    closeHatchWindow: () => {
+        console.log('Enviando close-hatch-window');
+        ipcRenderer.send('close-hatch-window');
     }
 });
 

--- a/scripts/hatch.js
+++ b/scripts/hatch.js
@@ -1,0 +1,52 @@
+const hatchOverlay = document.getElementById('hatch-overlay');
+const hatchVideo = document.getElementById('hatch-video');
+const hatchName = document.getElementById('hatch-name');
+const hatchGif = document.getElementById('hatch-gif');
+const hatchInput = document.getElementById('hatch-name-input');
+const hatchOk = document.getElementById('hatch-ok');
+let hatchedPet = null;
+
+function showHatchAnimation(newPet) {
+    if (!hatchOverlay || !hatchVideo || !hatchName || !hatchGif || !hatchInput) return;
+    hatchedPet = newPet;
+    hatchGif.src = newPet.statusImage ? `Assets/Mons/${newPet.statusImage}` : (newPet.image ? `Assets/Mons/${newPet.image}` : 'Assets/Mons/eggsy.png');
+    hatchInput.value = '';
+    hatchName.style.display = 'none';
+    hatchOverlay.style.display = 'flex';
+    hatchVideo.style.display = 'block';
+    hatchVideo.currentTime = 0;
+    hatchVideo.play();
+    const showName = () => {
+        hatchVideo.pause();
+        hatchVideo.style.display = 'none';
+        hatchName.style.display = 'flex';
+        hatchInput.focus();
+    };
+    hatchVideo.onended = showName;
+    setTimeout(showName, 7000);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    hatchOk?.addEventListener('click', () => {
+        if (!hatchedPet) return;
+        const name = hatchInput.value.trim();
+        if (!name) return;
+        if (name.length > 15) {
+            alert('O nome do pet deve ter no máximo 15 caracteres!');
+            return;
+        }
+        window.electronAPI.send('rename-pet', { petId: hatchedPet.petId, newName: name });
+        hatchedPet = null;
+        window.electronAPI.send('close-hatch-window');
+    });
+
+    hatchInput?.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+            hatchOk.click();
+        }
+    });
+});
+
+window.electronAPI?.onPetCreated((newPet) => {
+    showHatchAnimation(newPet);
+});

--- a/scripts/nests.js
+++ b/scripts/nests.js
@@ -33,6 +33,7 @@ function createHatchButton(index) {
     btn.className = 'button small-button hatch-button';
     btn.textContent = 'Chocar';
     btn.addEventListener('click', () => {
+        window.electronAPI.send('open-hatch-window');
         window.electronAPI.hatchEgg(index);
     });
     return btn;


### PR DESCRIPTION
## Summary
- remove inline hatch overlay from nests page
- open a dedicated `hatch.html` window when an egg hatches
- handle hatch animation and naming in new `hatch.html`
- support the new hatch window in preload and main processes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685caf804864832aa7c6c6fe64c9e3ac