### PR TITLE
Adjust nests egg list scrollbar

### DIFF
--- a/nests.html
+++ b/nests.html
@@ -124,7 +124,7 @@
     </div>
     <div id="egg-select-overlay">
         <div id="egg-select-box">
-            <div id="egg-list"></div>
+            <div id="egg-list" class="scroll-container"></div>
         </div>
     </div>
     <script type="module" src="scripts/nests.js"></script>


### PR DESCRIPTION
## Summary
- add `scroll-container` class to the egg list so nests.html uses the same styled scrollbar as other screens

## Testing
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_685d23cc2c78832aad468e488ecd5eac