### PR TITLE
Fix hatch naming overlay

### DIFF
--- a/hatch.html
+++ b/hatch.html
@@ -8,7 +8,7 @@
     <style>
         html, body { width:100%; height:100%; margin:0; padding:0; background:transparent; }
         #hatch-overlay {
-            display: flex;
+            display: none;
             position: fixed;
             top: 0;
             left: 0;

--- a/main.js
+++ b/main.js
@@ -1113,8 +1113,18 @@ ipcMain.on('hatch-egg', async (event, index) => {
         const newPet = await petManager.createPet(petData);
         BrowserWindow.getAllWindows().forEach(w => {
             if (w.webContents) w.webContents.send('nests-data-updated', nests);
-            if (w.webContents) w.webContents.send('pet-created', newPet);
+            if (w !== hatchWindow && w.webContents) {
+                w.webContents.send('pet-created', newPet);
+            }
         });
+        if (hatchWindow && hatchWindow.webContents) {
+            const sendPet = () => hatchWindow.webContents.send('pet-created', newPet);
+            if (hatchWindow.webContents.isLoading()) {
+                hatchWindow.webContents.once('did-finish-load', sendPet);
+            } else {
+                sendPet();
+            }
+        }
     } catch (err) {
         console.error('Erro ao chocar ovo:', err);
     }


### PR DESCRIPTION
## Summary
- ensure hatch overlay starts hidden
- send pet-created event to hatch window only after it finishes loading

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685d9eb1f930832ab86155a766532d50