### PR TITLE
Implement elemental multiplier indicators

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -287,6 +287,6 @@
             </div>
         </div>
     </div>
-    <script src="scripts/journey-scene.js"></script>
+    <script type="module" src="scripts/journey-scene.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -957,12 +957,14 @@ ipcMain.on('open-journey-scene-window', async (event, data) => {
     if (!win) return;
     const enemy = await getRandomEnemyIdle(currentPet ? currentPet.statusImage : null);
     const enemyName = enemy ? path.basename(path.dirname(enemy)) : '';
+    const enemyElement = extractElementFromPath(enemy);
     win.webContents.on('did-finish-load', () => {
         win.webContents.send('scene-data', {
             background: data.background,
             playerPet: currentPet ? resolveIdleGif(currentPet.statusImage || currentPet.image) : null,
             enemyPet: enemy,
             enemyName,
+            enemyElement,
             statusEffects: currentPet ? currentPet.statusEffects || [] : []
         });
         if (currentPet) {
@@ -1443,6 +1445,16 @@ async function getRandomEnemyIdle(exclude) {
     if (filtered.length === 0) return null;
     const choice = filtered[Math.floor(Math.random() * filtered.length)];
     return path.relative(__dirname, choice).replace(/\\/g, '/');
+}
+
+function extractElementFromPath(p) {
+    if (!p) return null;
+    const parts = p.replace(/\\/g, '/').split('/');
+    const monsIdx = parts.indexOf('Mons');
+    if (monsIdx >= 0 && parts.length > monsIdx + 2) {
+        return parts[monsIdx + 2].toLowerCase();
+    }
+    return null;
 }
 
 module.exports = { app, ipcMain, globalShortcut, windowManager, petManager };

--- a/scripts/elements.js
+++ b/scripts/elements.js
@@ -1,0 +1,16 @@
+export const ELEMENT_MULTIPLIERS = {
+    fogo: { fogo: 1.0, agua: 1.2, terra: 1.2, ar: 0.8, puro: 0.9 },
+    agua: { fogo: 0.8, agua: 1.0, terra: 1.2, ar: 1.2, puro: 0.9 },
+    terra: { fogo: 0.8, agua: 0.8, terra: 1.0, ar: 1.2, puro: 0.9 },
+    ar: { fogo: 1.2, agua: 0.8, terra: 0.8, ar: 1.0, puro: 0.9 },
+    puro: { fogo: 1.0, agua: 1.0, terra: 1.0, ar: 1.0, puro: 1.2 }
+};
+
+export function getElementMultiplier(attacker, defender) {
+    attacker = attacker?.toLowerCase();
+    defender = defender?.toLowerCase();
+    if (!ELEMENT_MULTIPLIERS[attacker] || !ELEMENT_MULTIPLIERS[attacker][defender]) {
+        return 1.0;
+    }
+    return ELEMENT_MULTIPLIERS[attacker][defender];
+}

--- a/styles/main.css
+++ b/styles/main.css
@@ -85,6 +85,17 @@ img {
     padding: 4px 8px;
 }
 
+.move-indicator {
+    margin-left: 4px;
+    font-weight: bold;
+}
+.move-indicator.up {
+    color: #00ff00;
+}
+.move-indicator.down {
+    color: #ff4444;
+}
+
 .button:hover {
     background-color: #3a4250; /* Um tom mais claro para hover */
 }


### PR DESCRIPTION
## Summary
- show up/down arrows next to move names to indicate advantage or weakness
- use move element when calculating damage multipliers
- refresh move list when enemy element loads
- style arrow indicators

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685dc0915208832a84ee466dddc660b4