### PR TITLE
Add level and element info to journey battles

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -125,6 +125,26 @@
             font-weight: bold;
             text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
         }
+        .name-container {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+        }
+        .element-icon {
+            width: 24px;
+            height: 24px;
+            image-rendering: pixelated;
+        }
+        .pet-level {
+            color: #ffffff;
+            font-family: 'PixelOperator', sans-serif;
+            font-size: 14px;
+            padding: 1px 4px;
+            border-radius: 3px;
+            text-shadow: 2px 2px 4px rgba(0, 0, 0, 1);
+            font-weight: bold;
+            margin-bottom: 4px;
+        }
         .hud-bars {
             display: flex;
             flex-direction: column;
@@ -240,8 +260,15 @@
         <img id="scene-bg" src="" alt="cenário">
 
         <div id="player-hud" class="hud-container">
-            <img id="player-front" class="hud-pet" src="" alt="pet">
+            <div class="hud-front">
+                <img id="player-front" class="hud-pet" src="" alt="pet">
+                <div class="name-container">
+                    <img id="player-element" class="element-icon" src="" alt="elemento">
+                    <div id="player-name" class="pet-name"></div>
+                </div>
+            </div>
             <div class="hud-bars">
+                <div id="player-level" class="pet-level"></div>
                 <div class="health-bar">
                     <div class="bar" id="player-health-fill" style="width:100%"></div>
                 </div>
@@ -255,9 +282,13 @@
         <div id="enemy-hud" class="hud-container">
             <div class="hud-front">
                 <img id="enemy-front" class="hud-pet" src="" alt="inimigo">
-                <div id="enemy-name" class="pet-name"></div>
+                <div class="name-container">
+                    <img id="enemy-element" class="element-icon" src="" alt="elemento">
+                    <div id="enemy-name" class="pet-name"></div>
+                </div>
             </div>
             <div class="hud-bars">
+                <div id="enemy-level" class="pet-level"></div>
                 <div class="health-bar">
                     <div class="bar" id="enemy-health-fill" style="width:100%"></div>
                 </div>

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -367,6 +367,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const playerFront = document.getElementById('player-front');
     const enemyFront = document.getElementById('enemy-front');
     const enemyName = document.getElementById('enemy-name');
+    const playerName = document.getElementById('player-name');
+    const playerElementImg = document.getElementById('player-element');
+    const enemyElementImg = document.getElementById('enemy-element');
+    const playerLevelTxt = document.getElementById('player-level');
+    const enemyLevelTxt = document.getElementById('enemy-level');
     loadItemsInfo();
     loadStatusEffectsInfo().then(updateStatusIcons);
 
@@ -440,6 +445,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (data.enemyElement) {
             enemyElement = data.enemyElement;
+            if (enemyElementImg) {
+                enemyElementImg.src = `Assets/Elements/${enemyElement}.png`;
+                enemyElementImg.alt = enemyElement;
+            }
             updateMoves();
         }
 
@@ -452,6 +461,14 @@ document.addEventListener('DOMContentLoaded', () => {
     window.electronAPI.on('pet-data', (event, data) => {
         if (!data) return;
         pet = data;
+        if (playerName) playerName.textContent = data.name || '';
+        if (playerElementImg) {
+            const el = (data.element || 'default').toLowerCase();
+            playerElementImg.src = `Assets/Elements/${el}.png`;
+            playerElementImg.alt = el;
+        }
+        if (playerLevelTxt) playerLevelTxt.textContent = `Lvl ${data.level || 1}`;
+        if (enemyLevelTxt) enemyLevelTxt.textContent = `Lvl ${data.level || 1}`;
         playerHealth = data.currentHealth ?? playerHealth;
         playerMaxHealth = data.maxHealth ?? playerMaxHealth;
         const healthFill = document.getElementById('player-health-fill');


### PR DESCRIPTION
## Summary
- show element icons and pet names on the journey battle scene
- display current level above each health bar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685df26e6f38832a8145f5db1b15c26d