### PR TITLE
Improve training flow

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -64,7 +64,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'fade-out-start-music', // Sinalizar o fade-out da música de start
             'pen-updated',
             'nest-updated',
-            'nests-data-updated'
+            'nests-data-updated',
+            'activate-status-tab'
         ];
         if (validChannels.includes(channel)) {
             console.log(`Registrando listener para o canal: ${channel}`);

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -423,3 +423,13 @@ document.addEventListener('DOMContentLoaded', () => {
         closeWindow();
     });
 });
+
+// Ativar uma aba específica quando solicitado pelo processo principal
+window.electronAPI.on('activate-status-tab', (event, tabId) => {
+    const button = document.querySelector(`.tab-button[data-tab="${tabId}"]`);
+    if (button) {
+        button.click();
+    } else {
+        console.warn('Botão da aba', tabId, 'não encontrado');
+    }
+});


### PR DESCRIPTION
## Summary
- open status and training windows together
- focus the moves tab when training is opened
- re-center status window when closing training
- expose `activate-status-tab` event via preload

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e8921e1c8832a98112a5b7d40604e