### PR TITLE
Improve window positioning and transitions

### DIFF
--- a/main.js
+++ b/main.js
@@ -746,6 +746,9 @@ function createTrainWindow() {
     });
 
     trainWindow.loadFile('train.html');
+    trainWindow.once('ready-to-show', () => {
+        windowManager.centerWindow(trainWindow);
+    });
     windowManager.attachFadeHandlers(trainWindow);
     trainWindow.on('closed', () => {
         trainWindow = null;

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -337,6 +337,9 @@ class WindowManager {
         });
 
         this.statusWindow.loadFile('status.html');
+        this.statusWindow.once('ready-to-show', () => {
+            centerWindowAnimated(this.statusWindow);
+        });
         attachFadeHandlers(this.statusWindow);
         this.statusWindow.on('closed', () => {
             this.statusWindow = null;


### PR DESCRIPTION
## Summary
- center the status window when it's ready to show
- center the train window when it's ready to show

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b63ceec832abd3d857c201311fc