### PR TITLE
Improve hatching animation

### DIFF
--- a/hatch.html
+++ b/hatch.html
@@ -38,10 +38,10 @@
 </head>
 <body>
     <div id="hatch-overlay">
-        <video id="hatch-video" src="Assets/Mons/evolution.mp4" autoplay muted playsinline style="width:100%;height:100%;object-fit:contain;"></video>
-        <img id="hatch-video-gif" src="Assets/Mons/evolution.gif" style="display:none;width:100%;height:100%;object-fit:contain;" />
+        <video id="hatch-video" src="Assets/Mons/evolution.mp4" autoplay muted playsinline style="width:100%;height:100%;object-fit:contain;opacity:1;transition:opacity 0.5s ease;"></video>
+        <img id="hatch-video-gif" src="Assets/Mons/evolution.gif" style="display:none;width:100%;height:100%;object-fit:contain;opacity:1;transition:opacity 0.5s ease;" />
         <div id="hatch-name">
-            <img id="hatch-gif" src="" alt="Pet" style="width:128px;height:128px;image-rendering:pixelated;">
+            <img id="hatch-gif" src="" alt="Pet" style="width:128px;height:128px;image-rendering:pixelated;opacity:0;transform:scale(0.5);transition:opacity 0.5s ease,transform 0.5s ease;">
             <div>
                 <input type="text" id="hatch-name-input" placeholder="dê um nome para o seu novo pet!" maxlength="15">
                 <button class="button small-button" id="hatch-ok">OK</button>

--- a/scripts/hatch.js
+++ b/scripts/hatch.js
@@ -15,7 +15,11 @@ function showHatchAnimation(newPet) {
     hatchName.style.display = 'none';
     hatchOverlay.style.display = 'flex';
     hatchVideo.style.display = 'block';
+    hatchVideo.style.opacity = '1';
     hatchVideoGif.style.display = 'none';
+    hatchVideoGif.style.opacity = '1';
+    hatchGif.style.opacity = '0';
+    hatchGif.style.transform = 'scale(0.5)';
     hatchVideo.currentTime = 0;
     const playPromise = hatchVideo.play();
     if (playPromise !== undefined) {
@@ -28,13 +32,28 @@ function showHatchAnimation(newPet) {
         hatchVideo.style.display = 'none';
         hatchVideoGif.style.display = 'block';
     };
-    const showName = () => {
-        hatchVideo.style.display = 'none';
-        hatchVideoGif.style.display = 'none';
-        hatchName.style.display = 'flex';
-        hatchInput.focus();
+    const showPet = () => {
+        hatchVideo.removeEventListener('ended', showPet);
+        hatchVideo.style.opacity = '0';
+        hatchVideoGif.style.opacity = '0';
+        setTimeout(() => {
+            hatchVideo.style.display = 'none';
+            hatchVideoGif.style.display = 'none';
+            hatchName.style.display = 'flex';
+            hatchGif.style.opacity = '1';
+            hatchGif.style.transform = 'scale(1)';
+            setTimeout(() => {
+                hatchGif.style.transition = 'transform 0.2s ease';
+                hatchGif.style.transform = 'scale(1) translateY(-20px)';
+                setTimeout(() => {
+                    hatchGif.style.transform = 'scale(1) translateY(0)';
+                }, 200);
+            }, 500);
+            hatchInput.focus();
+        }, 500);
     };
-    setTimeout(showName, 7000);
+    hatchVideo.addEventListener('ended', showPet);
+    setTimeout(showPet, 7000);
 }
 
 window.addEventListener('DOMContentLoaded', () => {

--- a/scripts/nests.js
+++ b/scripts/nests.js
@@ -49,7 +49,11 @@ function showHatchAnimation(newPet) {
     hatchName.style.display = 'none';
     hatchOverlay.style.display = 'flex';
     hatchVideo.style.display = 'block';
+    hatchVideo.style.opacity = '1';
     hatchVideoGif.style.display = 'none';
+    hatchVideoGif.style.opacity = '1';
+    hatchGif.style.opacity = '0';
+    hatchGif.style.transform = 'scale(0.5)';
     hatchVideo.currentTime = 0;
     const playPromise = hatchVideo.play();
     if (playPromise !== undefined) {
@@ -62,13 +66,28 @@ function showHatchAnimation(newPet) {
         hatchVideo.style.display = 'none';
         hatchVideoGif.style.display = 'block';
     };
-    const showName = () => {
-        hatchVideo.style.display = 'none';
-        hatchVideoGif.style.display = 'none';
-        hatchName.style.display = 'flex';
-        hatchInput.focus();
+    const showPet = () => {
+        hatchVideo.removeEventListener('ended', showPet);
+        hatchVideo.style.opacity = '0';
+        hatchVideoGif.style.opacity = '0';
+        setTimeout(() => {
+            hatchVideo.style.display = 'none';
+            hatchVideoGif.style.display = 'none';
+            hatchName.style.display = 'flex';
+            hatchGif.style.opacity = '1';
+            hatchGif.style.transform = 'scale(1)';
+            setTimeout(() => {
+                hatchGif.style.transition = 'transform 0.2s ease';
+                hatchGif.style.transform = 'scale(1) translateY(-20px)';
+                setTimeout(() => {
+                    hatchGif.style.transform = 'scale(1) translateY(0)';
+                }, 200);
+            }, 500);
+            hatchInput.focus();
+        }, 500);
     };
-    setTimeout(showName, 7000); // fallback
+    hatchVideo.addEventListener('ended', showPet);
+    setTimeout(showPet, 7000); // fallback
 }
 
 function hasEggInInventory() {


### PR DESCRIPTION
## Summary
- animate fade between hatching video and pet reveal
- add zoom and jump effect when showing the new pet

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ea19196d8832aab6d41c6347993dd