### PR TITLE
Add equipable pet items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,10 @@ Assets/Modes/Journeys/village.png
 assets/tileset/tileset.png
 assets/tileset/nest.png
 Assets/Shop/chocolate.png
+Assets/Shop/feather.png
+Assets/Shop/finger.png
+Assets/Shop/orbe.png
+Assets/Shop/turtle_shell.png
 
 # Hatching animations
 Assets/Mons/evolution.mp4

--- a/data/items.json
+++ b/data/items.json
@@ -28,6 +28,38 @@
     "effect": "Restaura 20 de felicidade, 10 de energia e 3 de fome."
   },
   {
+    "id": "finger",
+    "name": "Garra do Predador",
+    "icon": "Assets/Shop/finger.png",
+    "description": "Aumenta o ataque em 20% quando equipado.",
+    "effect": "Equipamento que aumenta o ataque em 20%.",
+    "type": "equipment"
+  },
+  {
+    "id": "turtleShell",
+    "name": "Casco de Protetor",
+    "icon": "Assets/Shop/turtle_shell.png",
+    "description": "Aumenta a defesa em 20% quando equipado.",
+    "effect": "Equipamento que aumenta a defesa em 20%.",
+    "type": "equipment"
+  },
+  {
+    "id": "feather",
+    "name": "Pena da Tempestade",
+    "icon": "Assets/Shop/feather.png",
+    "description": "Aumenta a velocidade em 20% quando equipado.",
+    "effect": "Equipamento que aumenta a velocidade em 20%.",
+    "type": "equipment"
+  },
+  {
+    "id": "orbe",
+    "name": "Orbe de Éter",
+    "icon": "Assets/Shop/orbe.png",
+    "description": "Aumenta a magia em 20% quando equipado.",
+    "effect": "Equipamento que aumenta a magia em 20%.",
+    "type": "equipment"
+  },
+  {
     "id": "terrainMedium",
     "name": "Terreno Médio",
     "icon": "assets/tileset/tileset.png",

--- a/main.js
+++ b/main.js
@@ -1053,6 +1053,10 @@ ipcMain.on('buy-item', async (event, item) => {
         meat: 5,
         staminaPotion: 8,
         chocolate: 2,
+        finger: 35,
+        turtleShell: 35,
+        feather: 35,
+        orbe: 35,
         terrainMedium: 100,
         terrainLarge: 200
     };
@@ -1129,6 +1133,12 @@ ipcMain.on('use-item', async (event, item) => {
             currentPet.energy = Math.min((currentPet.energy || 0) + 10, 100);
             currentPet.hunger = Math.min((currentPet.hunger || 0) + 3, 100);
             break;
+        case 'finger':
+        case 'turtleShell':
+        case 'feather':
+        case 'orbe':
+            currentPet.equippedItem = item;
+            break;
     }
 
     items[item] -= 1;
@@ -1140,7 +1150,8 @@ ipcMain.on('use-item', async (event, item) => {
             currentHealth: currentPet.currentHealth,
             hunger: currentPet.hunger,
             happiness: currentPet.happiness,
-            energy: currentPet.energy
+            energy: currentPet.energy,
+            equippedItem: currentPet.equippedItem
         });
     } catch (err) {
         console.error('Erro ao usar item:', err);

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -111,7 +111,7 @@ function updateItems() {
                 window.electronAPI.send('place-egg-in-nest', id);
             });
         } else {
-            useBtn.textContent = 'Usar';
+            useBtn.textContent = info.type === 'equipment' ? 'Equipar' : 'Usar';
             useBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
                 window.electronAPI.send('use-item', id);

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -122,7 +122,8 @@ async function createPet(petData) {
         bioImage: petData.bioImage || null,
         statusImage: petData.statusImage || null,
         items: {},
-        statusEffects: []
+        statusEffects: [],
+        equippedItem: null
     };
 
     ensureStatusImage(newPet);
@@ -150,15 +151,18 @@ async function listPets() {
                 try {
                     const data = await fs.readFile(filePath, 'utf8');
                     const pet = JSON.parse(data);
-                    if (pet.kadirPoints === undefined) {
-                        pet.kadirPoints = 5;
-                    }
+                   if (pet.kadirPoints === undefined) {
+                       pet.kadirPoints = 5;
+                   }
                    if (pet.items === undefined) {
                        pet.items = {};
                    }
                    if (pet.statusEffects === undefined) {
                        pet.statusEffects = [];
                    }
+                    if (pet.equippedItem === undefined) {
+                        pet.equippedItem = null;
+                    }
                     if (pet.winStreak === undefined) {
                         pet.winStreak = 0;
                     }
@@ -202,6 +206,9 @@ async function loadPet(petId) {
        if (pet.statusEffects === undefined) {
            pet.statusEffects = [];
        }
+        if (pet.equippedItem === undefined) {
+            pet.equippedItem = null;
+        }
         if (pet.winStreak === undefined) {
             pet.winStreak = 0;
         }

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -13,6 +13,7 @@ function getRequiredXpForNextLevel(level) {
 console.log('status.js carregado com sucesso');
 
 let pet = {};
+let itemsInfo = {};
 
 let descriptionEl = null;
 
@@ -33,6 +34,17 @@ function hideDescription() {
 let renameModal = null;
 let renameInput = null;
 let cheatBuffer = '';
+
+async function loadItemsInfo() {
+    try {
+        const resp = await fetch('data/items.json');
+        const data = await resp.json();
+        itemsInfo = {};
+        data.forEach(it => { itemsInfo[it.id] = it; });
+    } catch (err) {
+        console.error('Erro ao carregar infos de itens:', err);
+    }
+}
 
 function activateKadirFull() {
     if (!pet || !pet.petId) return;
@@ -128,6 +140,7 @@ function updateStatus() {
     const statusLevel = document.getElementById('status-level');
     const statusKadirPoints = document.getElementById('kadir-points-value');
     const statusMoves = document.getElementById('status-moves');
+    const statusEquipImg = document.getElementById('status-equipped-item');
     const statusPetImage = document.getElementById('status-pet-image');
     const statusBioImage = document.getElementById('status-bio-image');
     const bioText = document.getElementById('bio-text');
@@ -141,7 +154,7 @@ function updateStatus() {
     const statusPetImageGradient = document.getElementById('status-pet-image-gradient');
 
     // Verificar se todos os elementos estão disponíveis
-    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusKadirPoints || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText || !xpBarFill || !xpText || !specieText || !raceText || !elementText) {
+    if (!healthContainer || !hungerContainer || !happinessContainer || !energyContainer || !statusAttack || !statusDefense || !statusSpeed || !statusMagic || !statusRarityLabel || !statusHealthFill || !statusHungerFill || !statusHappinessFill || !statusEnergyFill || !statusLevel || !statusKadirPoints || !statusMoves || !statusPetImage || !statusBioImage || !titleBarElement || !titleBarPetName || !statusPetImageGradient || !bioText || !xpBarFill || !xpText || !specieText || !raceText || !elementText || !statusEquipImg) {
         console.error('Um ou mais elementos do status-container ou title-bar não encontrados', {
             healthContainer: !!healthContainer,
             hungerContainer: !!hungerContainer,
@@ -168,7 +181,8 @@ function updateStatus() {
             xpText: !!xpText,
             specieText: !!specieText,
             raceText: !!raceText,
-            elementText: !!elementText
+            elementText: !!elementText,
+            statusEquipImg: !!statusEquipImg
         });
         return;
     }
@@ -190,10 +204,29 @@ function updateStatus() {
     statusHunger.textContent = `${pet.hunger || 0}/100`;
     statusHappiness.textContent = `${pet.happiness || 0}/100`;
     statusEnergy.textContent = `${pet.energy || 0}/100`;
-    statusAttack.textContent = pet.attributes?.attack || 0;
-    statusDefense.textContent = pet.attributes?.defense || 0;
-    statusSpeed.textContent = pet.attributes?.speed || 0;
-    statusMagic.textContent = pet.attributes?.magic || 0;
+
+    let atk = pet.attributes?.attack || 0;
+    let def = pet.attributes?.defense || 0;
+    let spd = pet.attributes?.speed || 0;
+    let mag = pet.attributes?.magic || 0;
+    switch (pet.equippedItem) {
+        case 'finger':
+            atk = Math.round(atk * 1.2);
+            break;
+        case 'turtleShell':
+            def = Math.round(def * 1.2);
+            break;
+        case 'feather':
+            spd = Math.round(spd * 1.2);
+            break;
+        case 'orbe':
+            mag = Math.round(mag * 1.2);
+            break;
+    }
+    statusAttack.textContent = atk;
+    statusDefense.textContent = def;
+    statusSpeed.textContent = spd;
+    statusMagic.textContent = mag;
     statusRarityLabel.textContent = formatRarity(pet.rarity).toUpperCase();
     statusLevel.innerHTML = `<strong>Level: ${pet.level || 0}</strong>`;
     statusKadirPoints.textContent = pet.kadirPoints ?? 0;
@@ -296,6 +329,16 @@ function updateStatus() {
         setImageWithFallback(statusPetImage, pet.image);
     }
 
+    if (statusEquipImg) {
+        const info = itemsInfo[pet.equippedItem];
+        if (info && info.icon) {
+            statusEquipImg.src = info.icon;
+            statusEquipImg.style.display = 'block';
+        } else {
+            statusEquipImg.style.display = 'none';
+        }
+    }
+
     if (statusBioImage) {
         let bioPath = null;
         const dir = specieDirs[pet.specie];
@@ -346,6 +389,8 @@ function updateTabImage(tabId) {
 
 document.addEventListener('DOMContentLoaded', () => {
     console.log('DOM carregado na janela de status');
+
+    loadItemsInfo();
 
     descriptionEl = document.getElementById('move-description');
 

--- a/status.html
+++ b/status.html
@@ -182,14 +182,28 @@
 
         #status-rarity-label {
             position: absolute;
-            bottom: 5px;
-            right: 5px;
+            top: 5px;
+            left: 5px;
             font-size: 14px;
             color: #ffffff;
             background-color: rgba(0, 0, 0, 0.5);
             padding: 2px 5px;
             border-radius: 3px;
             z-index: 4;
+        }
+
+        #status-equipped-item {
+            position: absolute;
+            bottom: 5px;
+            right: 5px;
+            width: 32px;
+            height: 32px;
+            border-radius: 3px;
+            border: 2px solid #ffffff;
+            background-color: #2a323e;
+            image-rendering: pixelated;
+            z-index: 4;
+            display: none;
         }
 
         #status-level {
@@ -494,6 +508,7 @@
                         <img id="status-bio-image" src="" alt="Bio do Pet" style="image-rendering: pixelated;">
                         <div id="status-rarity-label">RARIDADE</div>
                         <div id="status-level">Level: 0</div>
+                        <img id="status-equipped-item" src="" alt="Equipamento">
                     </div>
                 </div>
                 <div class="tab-buttons">

--- a/store.html
+++ b/store.html
@@ -151,6 +151,26 @@
                 <div class="item-price">2 moedas</div>
                 <button class="button small-button buy-button" data-item="chocolate">Comprar</button>
             </div>
+            <div class="store-item" data-item="finger">
+                <img src="Assets/Shop/finger.png" alt="Garra do Predador">
+                <div class="item-price">35 moedas</div>
+                <button class="button small-button buy-button" data-item="finger">Comprar</button>
+            </div>
+            <div class="store-item" data-item="turtleShell">
+                <img src="Assets/Shop/turtle_shell.png" alt="Casco de Protetor">
+                <div class="item-price">35 moedas</div>
+                <button class="button small-button buy-button" data-item="turtleShell">Comprar</button>
+            </div>
+            <div class="store-item" data-item="feather">
+                <img src="Assets/Shop/feather.png" alt="Pena da Tempestade">
+                <div class="item-price">35 moedas</div>
+                <button class="button small-button buy-button" data-item="feather">Comprar</button>
+            </div>
+            <div class="store-item" data-item="orbe">
+                <img src="Assets/Shop/orbe.png" alt="Orbe de Éter">
+                <div class="item-price">35 moedas</div>
+                <button class="button small-button buy-button" data-item="orbe">Comprar</button>
+            </div>
             <div class="store-item" data-item="terrainMedium">
                 <img class="terrain-icon" src="assets/tileset/tileset.png" alt="Terreno Médio">
                 <div class="item-price">100 moedas</div>


### PR DESCRIPTION
## Summary
- add new equipment items to data and store page
- enable purchasing and equipping in main process
- display equipped item in status page
- adjust item UI and status logic for equipment
- include placeholder icons
- ignore equipment item icons in `.gitignore`
- remove duplicate variable in status script
- remove new shop icons from repository

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685ee4f30f94832a858e6157c53f915e