### PR TITLE
Add happiness icons logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,10 @@ Assets/Shop/turtle_shell.png
 # Hatching animations
 Assets/Mons/evolution.mp4
 Assets/Mons/evolution.gif
+
+# Happiness icons
+Assets/Shop/happy.png
+Assets/Shop/smile.png
+Assets/Shop/shy-smile.png
+Assets/Shop/poker-face.png
+Assets/Shop/sad.png

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -208,9 +208,16 @@ function adjustWarnings() {
     function updateStatusBubble() {
         if (!statusBubble) return;
         let icon = '';
-        if (petData.happiness > 90) {
+        const h = petData.happiness || 0;
+        if (h > 90) {
             icon = '<img src="Assets/Shop/happy.png" alt="Feliz">';
-        } else if (petData.happiness < 30) {
+        } else if (h > 70) {
+            icon = '<img src="Assets/Shop/smile.png" alt="Sorriso">';
+        } else if (h > 50) {
+            icon = '<img src="Assets/Shop/shy-smile.png" alt="Sorriso tímido">';
+        } else if (h > 30) {
+            icon = '<img src="Assets/Shop/poker-face.png" alt="Poker face">';
+        } else {
             icon = '<img src="Assets/Shop/sad.png" alt="Triste">';
         }
         statusBubble.innerHTML = icon;


### PR DESCRIPTION
## Summary
- ignore new happiness icons in git
- show different happiness icons in pet status bubble depending on pet happiness

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f0107515c832a98db5542a42ccf74