### PR TITLE
Show status bubble briefly when pet loads

### DIFF
--- a/index.html
+++ b/index.html
@@ -274,7 +274,7 @@
             border-radius: 5px;
             font-family: 'PixelOperator', sans-serif;
             font-size: 12px;
-            /* display: none; */
+            display: none;
             z-index: 8;
             text-align: left;
             box-shadow: 0px 1px 1px 1px black;

--- a/scripts/tray.js
+++ b/scripts/tray.js
@@ -162,8 +162,8 @@ function setImageWithFallback(imgElement, relativePath) {
 
     // Ajustar a posição dos alertas com base no decaimento
     adjustWarnings();
-    updateStatusBubble();
-    }
+    showStatusBubble();
+}
     
     // Função para ajustar a posição e exibição dos alertas
 function adjustWarnings() {
@@ -205,7 +205,7 @@ function adjustWarnings() {
     }
     }
 
-    function updateStatusBubble() {
+function updateStatusBubble() {
         if (!statusBubble) return;
         let icon = '';
         const h = petData.happiness || 0;
@@ -221,7 +221,17 @@ function adjustWarnings() {
             icon = '<img src="Assets/Shop/sad.png" alt="Triste">';
         }
         statusBubble.innerHTML = icon;
-    }
+}
+
+function showStatusBubble() {
+    if (!statusBubble) return;
+    updateStatusBubble();
+    statusBubble.style.display = 'block';
+    clearTimeout(statusBubble.hideTimeout);
+    statusBubble.hideTimeout = setTimeout(() => {
+        statusBubble.style.display = 'none';
+    }, 5000);
+}
 
     function getRandomItem() {
         if (!itemsData.length) return null;
@@ -260,13 +270,7 @@ function adjustWarnings() {
 
     if (petImageEl) {
         petImageEl.addEventListener('click', () => {
-            if (!statusBubble) return;
-            updateStatusBubble();
-            statusBubble.style.display = 'block';
-            clearTimeout(statusBubble.hideTimeout);
-            statusBubble.hideTimeout = setTimeout(() => {
-                statusBubble.style.display = 'none';
-            }, 5000);
+            showStatusBubble();
         });
         document.addEventListener('click', (e) => {
             if (statusBubble && !petImageEl.contains(e.target) && e.target !== statusBubble) {


### PR DESCRIPTION
## Summary
- hide the status bubble by default in `index.html`
- add a helper to show and hide the status bubble
- show the status bubble whenever a pet is loaded and when the pet is clicked

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f09179d10832a97b5ba6a594ed290