### PR TITLE
Add accessory swap confirmation

### DIFF
--- a/main.js
+++ b/main.js
@@ -1136,9 +1136,16 @@ ipcMain.on('use-item', async (event, item) => {
         case 'finger':
         case 'turtleShell':
         case 'feather':
-        case 'orbe':
+        case 'orbe': {
+            if (currentPet.equippedItem === item) {
+                return;
+            }
+            if (currentPet.equippedItem) {
+                items[currentPet.equippedItem] = (items[currentPet.equippedItem] || 0) + 1;
+            }
             currentPet.equippedItem = item;
             break;
+        }
     }
 
     items[item] -= 1;

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -114,6 +114,15 @@ function updateItems() {
             useBtn.textContent = info.type === 'equipment' ? 'Equipar' : 'Usar';
             useBtn.addEventListener('click', (e) => {
                 e.stopPropagation();
+                if (info.type === 'equipment' && pet.equippedItem && pet.equippedItem !== id) {
+                    const confirmSwap = window.confirm('Deseja trocar de acessório?');
+                    if (!confirmSwap) {
+                        return;
+                    }
+                }
+                if (info.type === 'equipment' && pet.equippedItem === id) {
+                    return;
+                }
                 window.electronAPI.send('use-item', id);
             });
         }


### PR DESCRIPTION
## Summary
- prompt before switching equipment and ignore if same item equipped
- return currently equipped item to inventory when equipping a new one

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f09dc75f4832a955b8e3de5b3fb7f