### PR TITLE
Add equipment management modal

### DIFF
--- a/main.js
+++ b/main.js
@@ -1168,6 +1168,24 @@ ipcMain.on('use-item', async (event, item) => {
     });
 });
 
+ipcMain.on('unequip-item', async () => {
+    if (!currentPet || !currentPet.equippedItem) return;
+    const items = getItems();
+    const eq = currentPet.equippedItem;
+    items[eq] = (items[eq] || 0) + 1;
+    currentPet.equippedItem = null;
+    setItems(items);
+    currentPet.items = items;
+    try {
+        await petManager.updatePet(currentPet.petId, { equippedItem: null });
+    } catch (err) {
+        console.error('Erro ao remover item:', err);
+    }
+    BrowserWindow.getAllWindows().forEach(w => {
+        if (w.webContents) w.webContents.send('pet-data', currentPet);
+    });
+});
+
 ipcMain.on('place-egg-in-nest', async (event, eggId) => {
     if (!currentPet) return;
     const items = getItems();

--- a/preload.js
+++ b/preload.js
@@ -22,6 +22,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'store-pet',
             'buy-item',
             'use-item',
+            'unequip-item',
             'train-pet',
             'learn-move',
             'rename-pet',

--- a/status.html
+++ b/status.html
@@ -607,6 +607,14 @@
         </div>
     </div>
 
+    <div id="equipment-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
+        <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
+            <div id="equip-items-container" style="display:flex; flex-direction:column; gap:5px; margin-bottom:8px;"></div>
+            <button id="unequip-item-button" class="button small-button" style="margin-bottom:8px;">Remover</button>
+            <button id="close-equip-modal" class="button small-button">Fechar</button>
+        </div>
+    </div>
+
     <script type="module" src="scripts/status.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- add modal to swap or remove equipped item
- implement open/close logic in status.js
- expose and handle `unequip-item` IPC channel

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f0c632624832a9a334c1a46a02b58