### PR TITLE
Use modal confirmation for item swap

### DIFF
--- a/items.html
+++ b/items.html
@@ -135,6 +135,15 @@
         <div id="items-list" class="scroll-container"></div>
         <button class="button small-button" id="open-store-button">Loja</button>
         <div id="item-description"></div>
+        <div id="swap-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
+            <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
+                <p style="margin-bottom:8px;">Deseja trocar de acessório?</p>
+                <div style="display:flex; justify-content:center; gap:10px;">
+                    <button id="swap-confirm" class="button small-button">Sim</button>
+                    <button id="swap-cancel" class="button small-button">Não</button>
+                </div>
+            </div>
+        </div>
     </div>
     <script type="module" src="scripts/items.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- replace `window.confirm` with a custom modal in **items.html**
- handle modal open/close logic in **items.js**

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f10210358832aaadb7b732bc14166