### PR TITLE
Add basic elemental moves

### DIFF
--- a/data/moves.json
+++ b/data/moves.json
@@ -296,5 +296,60 @@
     "effect": "queimado",
     "cost": 20,
     "level": 5
+  },
+  {
+    "name": "Faísca",
+    "description": "Golpe simples de fogo que causa dano leve.",
+    "rarity": "Comum",
+    "elements": ["fogo"],
+    "species": ["Draconídeo", "Ave", "Fera"],
+    "power": 10,
+    "effect": "nenhum",
+    "cost": 5,
+    "level": 1
+  },
+  {
+    "name": "Pedregulho",
+    "description": "Arremessa uma pedra para causar dano leve.",
+    "rarity": "Comum",
+    "elements": ["terra"],
+    "species": ["Draconídeo", "Ave", "Fera"],
+    "power": 10,
+    "effect": "nenhum",
+    "cost": 5,
+    "level": 1
+  },
+  {
+    "name": "Rajada de Vento",
+    "description": "Jato de ar que causa leve dano ao adversário.",
+    "rarity": "Comum",
+    "elements": ["ar"],
+    "species": ["Draconídeo", "Ave", "Fera"],
+    "power": 10,
+    "effect": "nenhum",
+    "cost": 5,
+    "level": 1
+  },
+  {
+    "name": "Jato D'água",
+    "description": "Disparo de água que acerta o inimigo com leve força.",
+    "rarity": "Comum",
+    "elements": ["agua"],
+    "species": ["Draconídeo", "Ave", "Fera"],
+    "power": 10,
+    "effect": "nenhum",
+    "cost": 5,
+    "level": 1
+  },
+  {
+    "name": "Luz Singela",
+    "description": "Luz pura que fere o inimigo com intensidade moderada.",
+    "rarity": "Comum",
+    "elements": ["puro"],
+    "species": ["Draconídeo", "Ave", "Fera"],
+    "power": 10,
+    "effect": "nenhum",
+    "cost": 5,
+    "level": 1
   }
 ]


### PR DESCRIPTION
## Summary
- include five basic moves representing fire, earth, air, water and pure elements

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f17d9f58c832aab14bfc890fa4a06