### PR TITLE
Update accessory slot and modal width

### DIFF
--- a/scripts/status.js
+++ b/scripts/status.js
@@ -396,9 +396,9 @@ function updateStatus() {
     if (statusEquipImg) {
         const info = itemsInfo[pet.equippedItem];
         if (info && info.icon) {
-            statusEquipImg.src = info.icon;
+            statusEquipImg.style.backgroundImage = `url(${info.icon})`;
         } else {
-            statusEquipImg.src = '';
+            statusEquipImg.style.backgroundImage = 'none';
         }
     }
 

--- a/status.html
+++ b/status.html
@@ -202,6 +202,9 @@
             border: 2px solid #ffffff;
             background-color: #2a323e;
             image-rendering: pixelated;
+            background-repeat: no-repeat;
+            background-position: center;
+            background-size: contain;
             z-index: 4;
             cursor: pointer;
         }
@@ -518,7 +521,7 @@
                         <img id="status-bio-image" src="" alt="Bio do Pet" style="image-rendering: pixelated;">
                         <div id="status-rarity-label">RARIDADE</div>
                         <div id="status-level">Level: 0</div>
-                        <img id="status-equipped-item" src="" alt="Equipamento">
+                        <div id="status-equipped-item"></div>
                     </div>
                 </div>
                 <div class="tab-buttons">
@@ -618,7 +621,7 @@
     </div>
 
     <div id="equipment-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
-        <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center; width:300px;">
+        <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center; width:320px;">
             <div id="equip-items-container" class="scroll-container" style="display:flex; flex-direction:column; gap:5px; margin-bottom:8px;"></div>
             <div style="display:flex; justify-content:center; gap:10px;">
                 <button id="unequip-item-button" class="button small-button">Remover</button>


### PR DESCRIPTION
## Summary
- style the accessory slot to use a background image
- convert accessory slot from `<img>` to `<div>`
- widen equipment modal by 20px
- update script to set accessory slot background

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f2dbc80c0832a9b9523f60d3723cd