### PR TITLE
Fix pen window size

### DIFF
--- a/main.js
+++ b/main.js
@@ -249,11 +249,18 @@ ipcMain.on("open-pen-window", () => {
         console.log("Load-pet window não está aberta. Ignorando pedido de abrir pen.");
         return;
     }
-    const penWin = windowManager.createPenWindow();
+    const info = getPenInfo();
+    const dimsMap = { small: { w: 4, h: 3 }, medium: { w: 5, h: 4 }, large: { w: 7, h: 5 } };
+    const dims = dimsMap[info.size] || dimsMap.small;
+    const w = (dims.w + 2) * 32;
+    const h = (dims.h + 2) * 32;
+    const border = 4; // canvas border size
+    const penWin = windowManager.createPenWindow(w + border, h + border);
     const nestsWin = createNestsWindow();
     if (penWin) {
         const lb = loadWin.getBounds();
         penWin.setPosition(lb.x + lb.width, lb.y);
+        penWin.setSize(w + border, h + border);
         updateNestsPosition();
         if (!penWin.__nestsMoveListener) {
             const reposition = updateNestsPosition;

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -19,8 +19,8 @@ function hasEggInInventory() {
 const MOVE_SPEED = 16; // pixels per second
 
 function getScale(size) {
-    // Pens larger than medium should be displayed slightly smaller
-    return size === 'large' ? 1.2 : 1.5;
+    // Keep a constant scale so the window size matches the pen exactly
+    return 1;
 }
 
 function drawPen() {
@@ -33,10 +33,10 @@ function drawPen() {
     penCanvas.height = h;
     penCanvas.style.transform = `scale(${scale})`;
     if (petsLayer) petsLayer.style.transform = `scale(${scale})`;
-    const padding = 20;
+    const border = 4; // canvas border width
     const size = {
-        width: Math.round(w * scale) + padding,
-        height: Math.round(h * scale) + padding
+        width: Math.round(w * scale) + border,
+        height: Math.round(h * scale) + border
     };
     window.electronAPI?.send('resize-pen-window', size);
     penCtx.clearRect(0,0,w,h);

--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -348,7 +348,7 @@ class WindowManager {
         return this.statusWindow;
     }
     // Criar a janela do cercado (pen.html)
-    createPenWindow() {
+    createPenWindow(width, height) {
         if (this.penWindow) {
             this.penWindow.focus();
             return this.penWindow;
@@ -356,8 +356,8 @@ class WindowManager {
 
         const preloadPath = path.join(__dirname, "..", "preload.js");
         this.penWindow = new BrowserWindow({
-            width: 370,
-            height: 300,
+            width: width || 370,
+            height: height || 300,
             frame: false,
             transparent: true,
             resizable: false,


### PR DESCRIPTION
## Summary
- resize pen window based on stored pen size when opening
- set border-based window size from pen renderer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685f3372040c832a88a22ad48585f12a