### PR TITLE
Implement code redemption

### DIFF
--- a/data/codes.json
+++ b/data/codes.json
@@ -1,0 +1,24 @@
+{
+  "WELCOME123": {
+    "used": false,
+    "pet": {
+      "name": "Foxy",
+      "element": "puro",
+      "attributes": {"attack": 5, "defense": 5, "life": 20, "speed": 5},
+      "specie": "Fera",
+      "rarity": "Comum",
+      "image": "Fera/foxyl.png"
+    }
+  },
+  "DRAGON999": {
+    "used": false,
+    "pet": {
+      "name": "Drako",
+      "element": "fogo",
+      "attributes": {"attack": 7, "defense": 6, "life": 25, "speed": 5},
+      "specie": "Draconídeo",
+      "rarity": "Raro",
+      "image": "Draconideo/draconideo_fogo.png"
+    }
+  }
+}

--- a/load-pet.html
+++ b/load-pet.html
@@ -253,6 +253,25 @@
             margin-bottom: 8px;
         }
 
+        .code-row {
+            display: flex;
+            justify-content: center;
+            gap: 10px;
+            margin-bottom: 8px;
+        }
+
+        #redeem-input {
+            background-color: #2a323e;
+            border: 2px solid #2a323e;
+            border-radius: 7px;
+            padding: 5px;
+            color: #ffffff;
+            font-family: 'PixelOperator', sans-serif;
+            font-size: 16px;
+            width: 200px;
+            text-align: center;
+        }
+
         .window {
             height: 430px;
         }
@@ -269,6 +288,10 @@
             <div class="button-row">
                 <button class="button" id="show-pen-button">Exibir Pets</button>
                 <button class="button" id="back-button">Voltar</button>
+            </div>
+            <div class="code-row">
+                <input type="text" id="redeem-input" placeholder="Digite o código" maxlength="20" />
+                <button class="button" id="redeem-button">Resgatar</button>
             </div>
         </div>
     </div>
@@ -469,6 +492,25 @@
 
         document.getElementById("show-pen-button").addEventListener("click", () => {
             window.electronAPI.send("open-pen-window");
+        });
+
+        const redeemBtn = document.getElementById('redeem-button');
+        const redeemInput = document.getElementById('redeem-input');
+        redeemBtn.addEventListener('click', () => {
+            const code = redeemInput.value.trim();
+            if (code) {
+                window.electronAPI.redeemCode(code);
+                redeemInput.value = '';
+            }
+        });
+
+        window.electronAPI.on('redeem-code-result', (event, result) => {
+            if (result.success) {
+                alert('Pet resgatado!');
+                reloadPetList();
+            } else {
+                alert(result.message || 'Código inválido');
+            }
         });
 
         // Voltar para a janela inicial

--- a/preload.js
+++ b/preload.js
@@ -39,6 +39,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'hatch-egg',
             'open-hatch-window',
             'close-hatch-window',
+            'redeem-code',
             'use-move',
             'update-health',
             'kadirfull',
@@ -66,7 +67,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'pen-updated',
             'nest-updated',
             'nests-data-updated',
-            'activate-status-tab'
+            'activate-status-tab',
+            'redeem-code-result'
         ];
         if (validChannels.includes(channel)) {
             console.log(`Registrando listener para o canal: ${channel}`);
@@ -142,6 +144,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     closeHatchWindow: () => {
         console.log('Enviando close-hatch-window');
         ipcRenderer.send('close-hatch-window');
+    },
+    redeemCode: (code) => {
+        console.log('Enviando redeem-code', code);
+        ipcRenderer.send('redeem-code', code);
     }
 });
 


### PR DESCRIPTION
## Summary
- add `codes.json` for mapping codes to pet data
- implement `redeem-code` IPC in `main.js` that creates pets and marks codes as used
- expose `redeemCode` and related channel in `preload.js`
- allow users to redeem codes via a new form in `load-pet.html`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fdf60d5ec832ab20663accc1fbc5e