### PR TITLE
Add shared api module

### DIFF
--- a/create-pet.html
+++ b/create-pet.html
@@ -191,7 +191,7 @@
         </div>
     </div>
 
-    <script src="scripts/create-pet.js"></script>
+    <script type="module" src="scripts/create-pet.js"></script>
 </body>
 
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,0 +1,23 @@
+/**
+ * Simple wrapper around backend API functions.
+ *
+ * The current implementation delegates to `window.electronAPI` so the
+ * renderer can work completely offline using Electron IPC.
+ * When the remote HTTP server is available, replace these calls with
+ * `fetch` requests to your endpoints and return the parsed responses.
+ */
+
+export function createPet(petData) {
+    window.electronAPI.createPet(petData);
+}
+
+export function listPets() {
+    return window.electronAPI.listPets();
+}
+
+export function redeemCode(code) {
+    if (window.electronAPI.redeemCode) {
+        return window.electronAPI.redeemCode(code);
+    }
+    return Promise.reject(new Error('redeemCode not implemented'));
+}

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -1,3 +1,4 @@
+import { createPet } from "./api.js";
 console.log('Script do create-pet.js carregado');
 
 // Informações de pasta e raça para cada espécie
@@ -292,7 +293,7 @@ function showNameSelection(element) {
         console.log('Pet a ser criado:', petData);
 
         // Enviar o pedido de criação do pet
-        window.electronAPI.createPet(petData);
+        createPet(petData);
 
         // Escutar a confirmação de criação e exibir a animação + revelar o pet
         window.electronAPI.onPetCreated((newPet) => {

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -1,3 +1,4 @@
+import { listPets } from "./api.js";
 const penCanvas = document.getElementById('pen-canvas');
 const petsLayer = document.getElementById('pets-layer');
 const nestsContainer = document.getElementById('nests-container');
@@ -143,10 +144,10 @@ function drawPets(pets) {
 }
 
 function loadPen() {
-    if (window.electronAPI && window.electronAPI.getPenInfo && window.electronAPI.listPets) {
+    if (window.electronAPI && window.electronAPI.getPenInfo) {
         Promise.all([
             window.electronAPI.getPenInfo(),
-            window.electronAPI.listPets()
+            listPets()
         ]).then(([info, pets]) => {
             penInfo = info;
             drawPen();

--- a/scripts/start.js
+++ b/scripts/start.js
@@ -1,3 +1,4 @@
+import { listPets } from "./api.js";
 console.log('Script do start.js carregado');
 console.log('window.electronAPI disponível:', typeof window.electronAPI !== 'undefined');
 
@@ -73,7 +74,7 @@ if (msg) msg.textContent = 'Você já possui um pet. Exclua-o para criar outro.'
 document.getElementById('start-button').addEventListener('click', () => {
     console.log('Botão Iniciar clicado');
     if (window.electronAPI) {
-        window.electronAPI.listPets().then(pets => {
+        listPets().then(pets => {
             if (pets.length >= petLimit) {
                 if (limitOverlay) limitOverlay.style.display = 'flex';
             } else {
@@ -131,7 +132,7 @@ exitNoBtn?.addEventListener('click', () => {
 // Verificar se há pets salvos e mostrar o botão "Carregar"
 if (window.electronAPI) {
     console.log('Listando pets...');
-    window.electronAPI.listPets().then(pets => {
+    listPets().then(pets => {
         console.log('Pets recebidos:', pets);
         if (pets.length > 0) {
             document.getElementById('load-button').style.display = 'block';

--- a/start.html
+++ b/start.html
@@ -181,7 +181,7 @@
         </div>
     </div>
 
-    <script src="scripts/start.js"></script>
+    <script type="module" src="scripts/start.js"></script>
 
 </body>
 


### PR DESCRIPTION
## Summary
- add `scripts/api.js` to centralize IPC calls
- switch start, create-pet and pen scripts to import from the new API module
- load these scripts as ES modules in their HTML files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fdf63c180832aa87715a8057d40d8