### PR TITLE
Fix hidden windows

### DIFF
--- a/scripts/windowManager.js
+++ b/scripts/windowManager.js
@@ -161,8 +161,8 @@ class WindowManager {
             },
         });
 
-        this.startWindow.loadFile('start.html');
         attachFadeHandlers(this.startWindow);
+        this.startWindow.loadFile('start.html');
         this.startWindow.on('closed', () => {
             this.startWindow = null;
         });
@@ -204,8 +204,8 @@ class WindowManager {
             },
         });
 
-        this.createPetWindow.loadFile('create-pet.html');
         attachFadeHandlers(this.createPetWindow);
+        this.createPetWindow.loadFile('create-pet.html');
         this.createPetWindow.on('closed', () => {
             this.createPetWindow = null;
         });
@@ -242,8 +242,8 @@ class WindowManager {
             },
         });
 
-        this.loadPetWindow.loadFile('load-pet.html');
         attachFadeHandlers(this.loadPetWindow);
+        this.loadPetWindow.loadFile('load-pet.html');
         this.loadPetWindow.on('closed', () => {
             this.loadPetWindow = null;
         });
@@ -298,8 +298,8 @@ class WindowManager {
             },
         });
 
-        this.trayWindow.loadFile('index.html');
         attachFadeHandlers(this.trayWindow);
+        this.trayWindow.loadFile('index.html');
         this.trayWindow.on('closed', () => {
             this.trayWindow = null;
         });
@@ -336,11 +336,11 @@ class WindowManager {
             },
         });
 
+        attachFadeHandlers(this.statusWindow);
         this.statusWindow.loadFile('status.html');
         this.statusWindow.once('ready-to-show', () => {
             centerWindowAnimated(this.statusWindow);
         });
-        attachFadeHandlers(this.statusWindow);
         this.statusWindow.on('closed', () => {
             this.statusWindow = null;
         });
@@ -369,8 +369,8 @@ class WindowManager {
             },
         });
 
-        this.penWindow.loadFile("pen.html");
         attachFadeHandlers(this.penWindow);
+        this.penWindow.loadFile("pen.html");
         this.penWindow.on("closed", () => {
             this.penWindow = null;
         });


### PR DESCRIPTION
## Summary
- ensure fade handlers are attached before loading pages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685fe4ef0b44832a956b82afa89c2e6b