### PR TITLE
Adjust force training behavior

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -44,6 +44,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'open-train-force-window',
             'use-move',
             'update-health',
+            'increase-attribute',
             'kadirfull',
             'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação

--- a/train-force.html
+++ b/train-force.html
@@ -11,7 +11,7 @@
         .window { position:relative; width:100%; height:100%; display:flex; flex-direction:column; padding:0; margin:0; }
         #force-content { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; position:relative; overflow:hidden; }
         #game-area { flex:1; width:100%; display:flex; align-items:center; justify-content:center; position:relative; background:url('Assets/train/forest.png') no-repeat center/cover; }
-        #log { width:80px; image-rendering:pixelated; }
+        #log { width:80px; image-rendering:pixelated; margin:0 auto; }
         #hit-effect { position:absolute; width:80px; display:none; pointer-events:none; }
         #precision-container { position:relative; width:80%; margin-top:5px; }
         #precision-bar { width:100%; image-rendering:pixelated; }


### PR DESCRIPTION
## Summary
- update force training to grant attribute points directly
- speed up power meter movement
- center log in force training page
- enlarge force training window size
- allow renderer to send `increase-attribute` events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863203f26d4832a862585ef7939f669