### PR TITLE
Implement training feedback overlay

### DIFF
--- a/train-force.html
+++ b/train-force.html
@@ -12,8 +12,14 @@
         #force-content { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; position:relative; overflow:hidden; }
         #game-area { flex:1; width:100%; display:flex; align-items:center; justify-content:center; position:relative; background:url('Assets/train/forest.png') no-repeat center/cover; }
         #log { width:80px; image-rendering:pixelated; margin:180px auto 0; }
-        #hit-effect { position:absolute; width:80px; display:none; pointer-events:none; }
-        #precision-container { position:relative; width:80%; margin-top:5px; }
+        #hit-effect {
+            position: absolute;
+            width: 80px;
+            display: none;
+            pointer-events: none;
+            top: 300px;
+        }
+        #precision-container { position:relative; width:60%; margin-top:5px; }
         #precision-bar { width:100%; image-rendering:pixelated; }
         /* Título configurado em styles/main.css */
         #close-train-force-window {
@@ -56,15 +62,29 @@
             image-rendering: pixelated;
         }
         #feedback {
-            position:absolute;
-            top:10px;
-            font-size:14px;
-            pointer-events:none;
-            opacity:0;
-            color:lime;
-            font-weight:bold;
-            text-shadow:1px 1px 2px #000;
+            position: absolute;
+            top: 180px;
+            font-size: 14px;
+            pointer-events: none;
+            opacity: 0;
+            color: lime;
+            font-weight: bold;
+            text-shadow: 1px 1px 2px #000;
         }
+        #force-results {
+            display: none;
+            position: absolute;
+            top: 40%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            background: rgba(0,0,0,0.8);
+            padding: 10px;
+            border-radius: 5px;
+            z-index: 10;
+            text-align: center;
+        }
+        #force-results p { margin: 3px 0; }
+        #force-results .gain { color: lime; }
         @keyframes floatUp { from { transform:translateY(0); opacity:1; } to { transform:translateY(-20px); opacity:0; } }
         #attempt-counter, #xp-total { font-size:14px; margin-top:2px; }
         #force-alert { display:none; position:absolute; top:40%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.8); padding:10px; border-radius:5px; z-index:10; }
@@ -91,6 +111,7 @@
             </div>
             <div id="attempt-counter"></div>
             <div id="xp-total"></div>
+            <div id="force-results"></div>
             <button class="button small-button" id="force-back">Voltar</button>
             <div id="force-alert"></div>
         </div>


### PR DESCRIPTION
## Summary
- tweak training bar and pointer movement
- add results overlay after final attempt
- adjust hit effect and feedback positioning

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863281f1d8c832aaf76c9aaeacad0f9