### PR TITLE
Add style for attribute training title bar

### DIFF
--- a/train-attributes.html
+++ b/train-attributes.html
@@ -13,6 +13,39 @@
         .attribute-row { display:flex; flex-direction:row; align-items:center; justify-content:center; gap:10px; }
         .attr-button { display:flex; flex-direction:column; align-items:center; justify-content:center; }
         .attr-button img { width:32px; height:32px; image-rendering: pixelated; margin-bottom:4px; }
+        /* Título configurado em styles/main.css */
+        #close-attributes-window {
+            width: 20px;
+            height: 20px;
+            background-color: #ff4444;
+            border-radius: 50%;
+            cursor: pointer;
+            -webkit-app-region: no-drag;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #813a3a;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
+        /* title-bar-buttons configurado em styles/main.css */
+        #back-attributes-window {
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- style back and close buttons in train-attributes title bar

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686331ddb4d0832a8c96177b73dd0a8f