### PR TITLE
Update force training modal

### DIFF
--- a/scripts/train-force.js
+++ b/scripts/train-force.js
@@ -67,27 +67,28 @@ function showFeedback(text, success) {
 
 function updateCounters() {
     const counter = document.getElementById('attempt-counter');
-    const total = document.getElementById('xp-total');
     if (counter) counter.textContent = `Tentativa ${attempts}/${maxAttempts}`;
-    if (total) total.textContent = attempts >= maxAttempts ? `Força total: ${totalXp}` : '';
 }
 
 function showResults() {
-    const resultsEl = document.getElementById('force-results');
-    if (!resultsEl || !pet) return;
+    const overlay = document.getElementById('force-results');
+    const content = document.getElementById('force-results-content');
+    if (!overlay || !content || !pet) return;
     const atk = pet.attributes?.attack ?? initialAttributes?.attack ?? 0;
     const def = pet.attributes?.defense ?? initialAttributes?.defense ?? 0;
     const spd = pet.attributes?.speed ?? initialAttributes?.speed ?? 0;
     const mag = pet.attributes?.magic ?? initialAttributes?.magic ?? 0;
-    resultsEl.innerHTML =
+    content.innerHTML =
         `<p>Ataque: ${atk} <span class="gain">+${totalXp}</span></p>` +
         `<p>Defesa: ${def}</p>` +
         `<p>Velocidade: ${spd}</p>` +
         `<p>Magia: ${mag}</p>` +
+        `<p>Força total: ${totalXp}</p>` +
         `<button class="button small-button" id="force-results-ok">Ok</button>`;
-    resultsEl.style.display = 'block';
+    overlay.style.display = 'flex';
     const okBtn = document.getElementById('force-results-ok');
     okBtn?.addEventListener('click', closeWindow);
+    document.getElementById('close-force-results')?.addEventListener('click', closeWindow);
 }
 
 function getAttrGain(high) {

--- a/train-force.html
+++ b/train-force.html
@@ -73,20 +73,46 @@
         }
         #force-results {
             display: none;
-            position: absolute;
-            top: 40%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            background: rgba(0,0,0,0.8);
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.7);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+        #force-results-window {
+            width: 240px;
+            height: auto;
+            display: flex;
+            flex-direction: column;
+        }
+        #force-results-content {
             padding: 10px;
-            border-radius: 5px;
-            z-index: 10;
             text-align: center;
         }
-        #force-results p { margin: 3px 0; }
-        #force-results .gain { color: lime; }
+        #force-results-content p { margin: 3px 0; }
+        #force-results-content .gain { color: lime; }
+        #close-force-results {
+            width: 20px;
+            height: 20px;
+            background-color: #ff4444;
+            border-radius: 50%;
+            cursor: pointer;
+            -webkit-app-region: no-drag;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #813a3a;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
         @keyframes floatUp { from { transform:translateY(0); opacity:1; } to { transform:translateY(-20px); opacity:0; } }
-        #attempt-counter, #xp-total { font-size:14px; margin-top:2px; }
+        #attempt-counter { font-size:14px; margin-top:2px; }
         #force-alert { display:none; position:absolute; top:40%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.8); padding:10px; border-radius:5px; z-index:10; }
     </style>
 </head>
@@ -110,8 +136,17 @@
                 <img id="pointer" src="Assets/train/chevron.png" alt="Ponteiro">
             </div>
             <div id="attempt-counter"></div>
-            <div id="xp-total"></div>
-            <div id="force-results"></div>
+            <div id="force-results" class="overlay">
+                <div id="force-results-window" class="window">
+                    <div id="title-bar">
+                        <div id="title-bar-content"><span>Resultados do treino</span></div>
+                        <div id="title-bar-buttons">
+                            <div id="close-force-results">X</div>
+                        </div>
+                    </div>
+                    <div id="force-results-content"></div>
+                </div>
+            </div>
             <button class="button small-button" id="force-back">Voltar</button>
             <div id="force-alert"></div>
         </div>


### PR DESCRIPTION
## Summary
- redesign train-force results overlay as a window with title bar
- remove XP total from the main view and show it only inside the results modal

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686333ec5ee8832a9ccc2d0ee88a7e40