### PR TITLE
Fix pet deletion path

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ O comando `npm start` executa `electron .` abrindo a janela inicial (`start.html
 ## Resumo do funcionamento
 
 - Na tela inicial é possível **criar** um novo pet ou **carregar** um existente.
-- Os dados dos pets ficam salvos no diretório `pets/`.
+- Os dados dos pets ficam salvos no diretório `pets/` dentro da pasta de dados do usuário (`userData`).
 - As imagens de cada pet ficam organizadas em pastas dentro de `Assets/Mons/`. Caso não exista uma pasta específica para um pet, a imagem `eggsy.png` é utilizada como padrão.
 - O atalho `Ctrl+Shift+D` abre as ferramentas de desenvolvedor do Electron.
 

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -1,10 +1,12 @@
 const fs = require('fs').promises;
 const fsSync = require('fs');
 const path = require('path');
+const { app } = require('electron');
 const Store = require('electron-store');
 const store = new Store();
 
-const petsDir = path.join(__dirname, '..', 'pets');
+// Diretório onde os arquivos de pets serão armazenados
+const petsDir = path.join(app.getPath('userData'), 'pets');
 let petCounter = 0;
 
 // Função para garantir que o diretório de pets exista


### PR DESCRIPTION
## Summary
- store pet data in Electron's `userData` directory
- update documentation about pet data location

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863d2cd3d74832ab2c6c4f765d373b2