### PR TITLE
Add KP requirement for training and start pets with 10 KP

### DIFF
--- a/main.js
+++ b/main.js
@@ -172,7 +172,7 @@ function generatePetFromEgg(eggId, rarity) {
         currentHealth: attributes.life,
         maxHealth: attributes.life,
         energy: 100,
-        kadirPoints: 5
+        kadirPoints: 10
     };
 }
 

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -286,7 +286,7 @@ function showNameSelection(element) {
             currentHealth: stats.life,
             maxHealth: stats.life,
             energy: 100,
-            kadirPoints: 5
+            kadirPoints: 10
         };
 
         console.log('Pet a ser criado:', petData);

--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -111,7 +111,7 @@ async function createPet(petData) {
         hunger: petData.hunger || 100,
         happiness: petData.happiness || 100,
         energy: petData.energy || 100,
-        kadirPoints: petData.kadirPoints || 5,
+        kadirPoints: petData.kadirPoints || 10,
         winStreak: 0,
         lossStreak: 0,
         currentHealth: petData.currentHealth || (petData.attributes?.life || 100),
@@ -154,7 +154,7 @@ async function listPets() {
                     const data = await fs.readFile(filePath, 'utf8');
                     const pet = JSON.parse(data);
                    if (pet.kadirPoints === undefined) {
-                       pet.kadirPoints = 5;
+                       pet.kadirPoints = 10;
                    }
                    if (pet.items === undefined) {
                        pet.items = {};
@@ -200,7 +200,7 @@ async function loadPet(petId) {
         const data = await fs.readFile(petFilePath, 'utf8');
         const pet = JSON.parse(data);
         if (pet.kadirPoints === undefined) {
-            pet.kadirPoints = 5;
+            pet.kadirPoints = 10;
         }
        if (pet.items === undefined) {
            pet.items = {};

--- a/scripts/train-force.js
+++ b/scripts/train-force.js
@@ -166,6 +166,11 @@ function checkEligibility() {
         alertEl.style.display = 'block';
         return false;
     }
+    if ((pet.kadirPoints || 0) < 1) {
+        alertEl.textContent = 'Seu pet não tem DNA Kadir suficiente para treinar.';
+        alertEl.style.display = 'block';
+        return false;
+    }
     alertEl.style.display = 'none';
     return true;
 }


### PR DESCRIPTION
## Summary
- ensure each new pet starts with 10 Kadir Points
- adjust pet loading to default to 10 KP
- block attribute training if the pet lacks KP

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6863d890a188832ab94626f5d77f507e