### PR TITLE
Add defense training mode

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ let trainWindow = null;
 let trainMenuWindow = null;
 let trainAttributesWindow = null;
 let trainForceWindow = null;
+let trainDefenseWindow = null;
 let itemsWindow = null;
 let storeWindow = null;
 let journeyImagesCache = null;
@@ -900,6 +901,38 @@ function createTrainForceWindow() {
     return trainForceWindow;
 }
 
+function createTrainDefenseWindow() {
+    if (trainDefenseWindow) {
+        trainDefenseWindow.show();
+        trainDefenseWindow.focus();
+        return trainDefenseWindow;
+    }
+
+    const preloadPath = require('path').join(__dirname, 'preload.js');
+
+    trainDefenseWindow = new BrowserWindow({
+        width: 1074,
+        height: 715,
+        frame: false,
+        transparent: true,
+        resizable: false,
+        show: false,
+        webPreferences: {
+            preload: preloadPath,
+            nodeIntegration: false,
+            contextIsolation: true,
+        },
+    });
+
+    trainDefenseWindow.loadFile('train-defense.html');
+    windowManager.attachFadeHandlers(trainDefenseWindow);
+    trainDefenseWindow.on('closed', () => {
+        trainDefenseWindow = null;
+    });
+
+    return trainDefenseWindow;
+}
+
 function createItemsWindow() {
     if (itemsWindow) {
         itemsWindow.show();
@@ -1217,6 +1250,19 @@ ipcMain.on('open-train-force-window', () => {
         return;
     }
     const win = createTrainForceWindow();
+    if (win) {
+        win.webContents.on('did-finish-load', () => {
+            win.webContents.send('pet-data', currentPet);
+        });
+    }
+});
+
+ipcMain.on('open-train-defense-window', () => {
+    if (!currentPet) {
+        console.error('Nenhum pet selecionado para treinar');
+        return;
+    }
+    const win = createTrainDefenseWindow();
     if (win) {
         win.webContents.on('did-finish-load', () => {
             win.webContents.send('pet-data', currentPet);

--- a/preload.js
+++ b/preload.js
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'open-train-menu-window',
             'open-train-attributes-window',
             'open-train-force-window',
+            'open-train-defense-window',
             'use-move',
             'update-health',
             'increase-attribute',

--- a/scripts/train-attributes.js
+++ b/scripts/train-attributes.js
@@ -12,4 +12,8 @@ document.addEventListener('DOMContentLoaded', () => {
         window.electronAPI.send('open-train-force-window');
         closeWindow();
     });
+    document.getElementById('train-defense-button')?.addEventListener('click', () => {
+        window.electronAPI.send('open-train-defense-window');
+        closeWindow();
+    });
 });

--- a/scripts/train-defense.js
+++ b/scripts/train-defense.js
@@ -1,0 +1,174 @@
+let pet = null;
+let running = false;
+let pointerPos = 0;
+let direction = 1;
+let frameId = 0;
+let attempts = 0;
+const maxAttempts = 5;
+const energyCostPerAttempt = 3; // 5 tentativas = 15 de energia
+const tolerances = [40, 30, 20, 15, 10];
+let xpDefesa = 0; // pontos de defesa ganhos
+let initialAttributes = null;
+
+function closeWindow() {
+    window.close();
+}
+
+function getPointerSpeed(level) {
+    const base = 0.4; // velocidade inicial mais lenta
+    const tier = Math.floor(((level || 1) - 1) / 5);
+    return Math.min(base + tier * 0.1, 1.2);
+}
+
+function startPointer() {
+    const pointer = document.getElementById('pointer');
+    const container = document.getElementById('precision-container');
+    if (!pointer || !container) return;
+    const containerWidth = container.offsetWidth;
+    const pointerWidth = pointer.offsetWidth;
+    const maxLeft = containerWidth - pointerWidth;
+    running = true;
+    const step = getPointerSpeed(pet?.level || 1);
+    function animate() {
+        if (!running) return;
+        pointerPos += step * direction;
+        if (pointerPos >= 100) { pointerPos = 100; direction = -1; }
+        if (pointerPos <= 0) { pointerPos = 0; direction = 1; }
+        const left = (pointerPos / 100) * maxLeft;
+        pointer.style.left = `${left}px`;
+        frameId = requestAnimationFrame(animate);
+    }
+    frameId = requestAnimationFrame(animate);
+}
+
+function stopPointer() {
+    running = false;
+    cancelAnimationFrame(frameId);
+}
+
+function showHitEffect() {
+    const effect = document.getElementById('hit-effect');
+    if (!effect) return;
+    effect.style.display = 'block';
+    setTimeout(() => { effect.style.display = 'none'; }, 300);
+}
+
+function showFeedback(text, success) {
+    const fb = document.getElementById('feedback');
+    if (!fb) return;
+    fb.textContent = text;
+    fb.style.color = success ? 'lime' : '#ff4444';
+    fb.style.opacity = '1';
+    fb.style.animation = 'none';
+    // trigger reflow
+    void fb.offsetWidth;
+    fb.style.animation = 'floatUp 1s forwards';
+}
+
+function updateCounters() {
+    const counter = document.getElementById('attempt-counter');
+    if (counter) counter.textContent = `Tentativa ${attempts}/${maxAttempts}`;
+}
+
+function showResults() {
+    const overlay = document.getElementById('defense-results');
+    const content = document.getElementById('defense-results-content');
+    if (!overlay || !content) return;
+    content.innerHTML =
+        `<p>Você ganhou <span class="gain">+${xpDefesa}</span> pontos de Defesa!</p>` +
+        `<button class="button small-button" id="defense-results-ok">Ok</button>`;
+    overlay.style.display = 'flex';
+    const okBtn = document.getElementById('defense-results-ok');
+    okBtn?.addEventListener('click', closeWindow);
+    document.getElementById('close-defense-results')?.addEventListener('click', closeWindow);
+}
+
+function evaluateHit() {
+    stopPointer();
+    showHitEffect();
+    const pointer = document.getElementById('pointer');
+    const container = document.getElementById('precision-container');
+    const shieldImg = document.getElementById('shield');
+    if (!pointer || !container) return;
+    const pointerLeft = parseFloat(pointer.style.left) || 0;
+    const containerWidth = container.offsetWidth;
+    const pointerWidth = pointer.offsetWidth;
+    const target = containerWidth / 2 - pointerWidth / 2;
+    const diff = Math.abs(pointerLeft - target);
+    const tolerance = tolerances[Math.min(attempts, tolerances.length - 1)];
+    const success = diff <= tolerance;
+    if (success) {
+        xpDefesa += 1;
+        if (shieldImg) shieldImg.src = 'Assets/train/shield-2.png';
+        showFeedback('Defesa bem-sucedida! +1 Defesa', true);
+    } else {
+        if (shieldImg) shieldImg.src = 'Assets/train/shield-3.png';
+        showFeedback('Errou o tempo!', false);
+    }
+    attempts += 1;
+    updateCounters();
+    if (pet) {
+        window.electronAPI.send('use-move', { cost: energyCostPerAttempt });
+        if (success) {
+            window.electronAPI.send('increase-attribute', { name: 'defense', amount: 1 });
+        }
+        window.electronAPI.send('reward-pet', { kadirPoints: -1 });
+    }
+    if (attempts < maxAttempts) {
+        setTimeout(() => {
+            if (shieldImg) shieldImg.src = 'Assets/train/shield-1.png';
+            pointerPos = 0;
+            direction = 1;
+            startPointer();
+        }, 500);
+    } else {
+        setTimeout(showResults, 500);
+    }
+}
+
+function handleInput() {
+    if (!running || attempts >= maxAttempts) return;
+    evaluateHit();
+}
+
+function checkEligibility() {
+    const alertEl = document.getElementById('defense-alert');
+    if (!pet || !alertEl) return false;
+    const lifePct = (pet.currentHealth / pet.maxHealth) * 100;
+    if (pet.energy < 15 || lifePct < 15) {
+        alertEl.textContent = 'Seu pet não tem energia ou vida suficiente para treinar.';
+        alertEl.style.display = 'block';
+        return false;
+    }
+    if ((pet.kadirPoints || 0) < 1) {
+        alertEl.textContent = 'Seu pet não tem DNA Kadir suficiente para treinar.';
+        alertEl.style.display = 'block';
+        return false;
+    }
+    alertEl.style.display = 'none';
+    return true;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('close-train-defense-window')?.addEventListener('click', closeWindow);
+    const backFn = () => { window.electronAPI.send('open-train-attributes-window'); closeWindow(); };
+    document.getElementById('back-train-defense-window')?.addEventListener('click', backFn);
+    document.getElementById('defense-back')?.addEventListener('click', backFn);
+    document.addEventListener('keydown', e => { if (e.code === 'Space') handleInput(); });
+    document.addEventListener('mousedown', handleInput);
+    window.electronAPI.on('pet-data', (event, data) => {
+        pet = data;
+        if (!initialAttributes && pet) {
+            initialAttributes = {
+                attack: pet.attributes?.attack || 0,
+                defense: pet.attributes?.defense || 0,
+                speed: pet.attributes?.speed || 0,
+                magic: pet.attributes?.magic || 0
+            };
+        }
+        if (checkEligibility()) {
+            updateCounters();
+            startPointer();
+        }
+    });
+});

--- a/train-attributes.html
+++ b/train-attributes.html
@@ -63,7 +63,7 @@
                     <img src="assets/train/forca.png" alt="Força">
                     <span>Força</span>
                 </button>
-                <button class="button attr-button" id="train-defense-button" disabled>
+                <button class="button attr-button" id="train-defense-button">
                     <img src="assets/train/defesa.png" alt="Defesa">
                     <span>Defesa</span>
                 </button>

--- a/train-defense.html
+++ b/train-defense.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'">
+    <title>Kadir11 - Treinar Defesa</title>
+    <link rel="stylesheet" href="styles/main.css">
+    <style>
+        html, body { width:100%; height:100%; margin:0; padding:0; background:transparent; }
+        .window { position:relative; width:100%; height:100%; display:flex; flex-direction:column; padding:0; margin:0; }
+        #defense-content { flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; position:relative; overflow:hidden; }
+        #game-area { flex:1; width:100%; display:flex; align-items:center; justify-content:center; position:relative; background:url('Assets/train/forest.png') no-repeat center/cover; }
+        #shield { width:80px; image-rendering:pixelated; margin:180px auto 0; }
+        #hit-effect {
+            position: absolute;
+            width: 80px;
+            display: none;
+            pointer-events: none;
+            top: 300px;
+        }
+        #precision-container { position:relative; width:60%; margin-top:5px; }
+        #precision-bar { width:100%; image-rendering:pixelated; }
+        #defense-target {
+            position: absolute;
+            top: 0;
+            left: 50%;
+            width: 2px;
+            height: 100%;
+            background: red;
+            transform: translateX(-1px);
+        }
+        /* Título configurado em styles/main.css */
+        #close-train-defense-window {
+            width: 20px;
+            height: 20px;
+            background-color: #ff4444;
+            border-radius: 50%;
+            cursor: pointer;
+            -webkit-app-region: no-drag;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #813a3a;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
+        /* title-bar-buttons configurado em styles/main.css */
+        #back-train-defense-window {
+            width: 20px;
+            height: 20px;
+            background-color: #44aaff;
+            border-radius: 50%;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #2a435b;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
+        #pointer {
+            position: absolute;
+            top: 3px;
+            left: 0;
+            width: 40px;
+            image-rendering: pixelated;
+        }
+        #feedback {
+            position: absolute;
+            top: 200px;
+            font-size: 14px;
+            pointer-events: none;
+            opacity: 0;
+            color: lime;
+            font-weight: bold;
+            text-shadow: 1px 1px 2px #000;
+        }
+        #defense-results {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: rgba(0,0,0,0.7);
+            z-index: 1000;
+            align-items: center;
+            justify-content: center;
+        }
+        #defense-results-window {
+            width: 240px;
+            height: auto;
+            display: flex;
+            flex-direction: column;
+        }
+        #defense-results-content {
+            padding: 10px;
+            text-align: center;
+        }
+        #defense-results-content p { margin: 3px 0; }
+        #defense-results-content .gain { color: lime; }
+        #close-defense-results {
+            width: 20px;
+            height: 20px;
+            background-color: #ff4444;
+            border-radius: 50%;
+            cursor: pointer;
+            -webkit-app-region: no-drag;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: #813a3a;
+            font-family: cursive;
+            font-size: 12px;
+            font-weight: bold;
+            text-shadow: none;
+        }
+        @keyframes floatUp { from { transform:translateY(0); opacity:1; } to { transform:translateY(-20px); opacity:0; } }
+        #attempt-counter { font-size:14px; margin-top:2px; }
+        #defense-alert { display:none; position:absolute; top:40%; left:50%; transform:translate(-50%,-50%); background:rgba(0,0,0,0.8); padding:10px; border-radius:5px; z-index:10; }
+    </style>
+</head>
+<body>
+    <div class="window">
+        <div id="title-bar">
+            <div id="title-bar-content"><span>Treinar Defesa</span></div>
+            <div id="title-bar-buttons">
+                <div id="back-train-defense-window">↩</div>
+                <div id="close-train-defense-window">X</div>
+            </div>
+        </div>
+        <div id="defense-content">
+            <div id="game-area">
+                <img id="shield" src="Assets/train/shield-1.png" alt="Escudo">
+                <img id="hit-effect" src="Assets/train/hit.gif" alt="Hit">
+                <div id="feedback"></div>
+            </div>
+            <div id="precision-container">
+                <img id="precision-bar" src="Assets/train/bar.png" alt="Barra">
+                <div id="defense-target"></div>
+                <img id="pointer" src="Assets/train/chevron.png" alt="Ponteiro">
+            </div>
+            <div id="attempt-counter"></div>
+            <div id="defense-results" class="overlay">
+                <div id="defense-results-window" class="window">
+                    <div id="title-bar">
+                        <div id="title-bar-content"><span>Resultados do treino</span></div>
+                        <div id="title-bar-buttons">
+                            <div id="close-defense-results">X</div>
+                        </div>
+                    </div>
+                    <div id="defense-results-content"></div>
+                </div>
+            </div>
+            <button class="button small-button" id="defense-back">Voltar</button>
+            <div id="defense-alert"></div>
+        </div>
+    </div>
+    <script type="module" src="scripts/train-defense.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable Defense button in attribute menu
- handle open-train-defense-window on renderer side
- add new train-defense.html and train-defense.js implementing timed defense training
- allow sending new IPC channel in preload
- implement createTrainDefenseWindow and listener in main process

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686535bac108832aa8f54fa0e68aa7bd