### PR TITLE
Flip ball direction in defense training

### DIFF
--- a/scripts/train-defense.js
+++ b/scripts/train-defense.js
@@ -65,6 +65,11 @@ function startPointer() {
         }
         if (nextBallFromRight !== null) {
             ballFromRight = nextBallFromRight;
+            if (ball) {
+                ball.classList.toggle('flipped', ballFromRight);
+            }
+        } else if (ball) {
+            ball.classList.toggle('flipped', ballFromRight);
         }
         frameId = requestAnimationFrame(animate);
     }

--- a/train-defense.html
+++ b/train-defense.html
@@ -19,6 +19,9 @@
             width: 40px;
             image-rendering: pixelated;
         }
+        #ball.flipped {
+            transform: scaleX(-1);
+        }
         #hit-effect {
             position: absolute;
             width: 80px;


### PR DESCRIPTION
## Summary
- add CSS class to flip the training ball
- toggle the class based on ball direction

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865410998d0832a9d2b4c4f6dff5789