### PR TITLE
Adjust lair-mode dimensions

### DIFF
--- a/lair-mode.html
+++ b/lair-mode.html
@@ -27,7 +27,8 @@
         </div>
     </div>
     <div id="lair-container">
-        <canvas id="lair-canvas" width="1280" height="960"></canvas>
+        <!-- 32x24 tiles de 32px -->
+        <canvas id="lair-canvas" width="1024" height="768"></canvas>
         <img id="player-sprite" src="" alt="Player">
         <div id="ui">
             <span id="bravura-text">Bravura: 0</span>

--- a/scripts/lair-mode.js
+++ b/scripts/lair-mode.js
@@ -1,8 +1,10 @@
 console.log('lair-mode.js carregado');
 
 const TILE_SIZE = 32;
-const MAP_W = 40;
-const MAP_H = 30;
+// Dimensões do mapa diminuídas para reduzir o tamanho da janela
+// Cada tile possui 32px, então 32x24 resulta em 1024x768
+const MAP_W = 32;
+const MAP_H = 24;
 
 const tileMapping = {
     FLOOR: [3,6],


### PR DESCRIPTION
## Summary
- shrink lair-mode to a 32x24 tile map (1024x768 canvas)
- use standard title bar with back and close buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866e4f7198c832aa5d2fd7cb2ead479