### PR TITLE
Update lair mode UI and battle background

### DIFF
--- a/lair-mode.html
+++ b/lair-mode.html
@@ -11,8 +11,13 @@
     .window { position:relative; display:flex; flex-direction:column; width:fit-content; height:fit-content; }
     #close-lair-mode { width:20px; height:20px; background:#ff4444; border-radius:50%; cursor:pointer; -webkit-app-region:no-drag; display:flex; align-items:center; justify-content:center; color:#813a3a; font-family:cursive; font-size:12px; font-weight:bold; text-shadow:none; }
     #back-lair-mode { width:20px; height:20px; background:#44aaff; border-radius:50%; cursor:pointer; display:flex; align-items:center; justify-content:center; color:#2a435b; font-family:cursive; font-size:12px; font-weight:bold; text-shadow:none; }
-    #lair-container { position:relative; margin:40px 10px 10px; }
-    #lair-canvas { display:block; image-rendering:pixelated; }
+    #lair-container { position: relative; margin: 10px 10px 10px; }
+    #lair-canvas {
+        display: block;
+        image-rendering: pixelated;
+        transform: scale(1.2);
+        transform-origin: top left;
+    }
     #player-sprite { position:absolute; width:32px; height:32px; image-rendering:pixelated; pointer-events:none; }
     #ui { margin-top:5px; font-family:'PixelOperator', sans-serif; color:#fff; }
 </style>
@@ -27,8 +32,8 @@
         </div>
     </div>
     <div id="lair-container">
-        <!-- 32x24 tiles de 32px -->
-        <canvas id="lair-canvas" width="1024" height="768"></canvas>
+        <!-- 26x20 tiles de 32px -->
+        <canvas id="lair-canvas" width="832" height="640"></canvas>
         <img id="player-sprite" src="" alt="Player">
         <div id="ui">
             <span id="bravura-text">Bravura: 0</span>

--- a/scripts/lair-mode.js
+++ b/scripts/lair-mode.js
@@ -1,10 +1,10 @@
 console.log('lair-mode.js carregado');
 
 const TILE_SIZE = 32;
-// Dimensões do mapa diminuídas para reduzir o tamanho da janela
-// Cada tile possui 32px, então 32x24 resulta em 1024x768
-const MAP_W = 32;
-const MAP_H = 24;
+// Dimensões do mapa ajustadas para caber na janela ao escalar o canvas
+// Cada tile possui 32px, então 26x20 resulta em 832x640 (escala 1.2 ≈ 1000x768)
+const MAP_W = 26;
+const MAP_H = 20;
 
 const tileMapping = {
     FLOOR: [3,6],
@@ -83,7 +83,9 @@ function updateUI(){
 
 function handleTile(tile){
     if(tile==='MONSTER'){
-        window.electronAPI.send('open-journey-scene-window',{background:'assets/modes/lair.png'});
+        window.electronAPI.send('open-journey-scene-window', {
+            background: 'Assets/Modes/Journeys/cave_ruin.png'
+        });
         map[player.y][player.x]='FLOOR';
     }else if(tile==='BOX'){
         window.electronAPI.send('reward-pet',{item:'meat',qty:1});


### PR DESCRIPTION
## Summary
- tweak layout for lair mode page
- scale the lair canvas so tiles appear larger
- reduce the number of tiles drawn
- always use the cave ruin background for lair battles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866e769a53c832aa851e17ae1eb1611