### PR TITLE
Fix lair scaling and defeat return

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -317,6 +317,12 @@
                 <button id="victory-close" class="button small-button">OK</button>
             </div>
         </div>
+        <div id="defeat-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
+            <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
+                <div style="margin-bottom:8px;">Você perdeu!</div>
+                <button id="defeat-close" class="button small-button">OK</button>
+            </div>
+        </div>
     </div>
     <script type="module" src="scripts/journey-scene.js"></script>
 </body>

--- a/lair-mode.html
+++ b/lair-mode.html
@@ -15,10 +15,17 @@
     #lair-canvas {
         display: block;
         image-rendering: pixelated;
-        transform: scale(1.2);
+        transform: scale(var(--lair-scale, 1));
         transform-origin: top left;
     }
-    #player-sprite { position:absolute; width:32px; height:32px; image-rendering:pixelated; pointer-events:none; }
+    #player-sprite {
+        position: absolute;
+        width: 32px;
+        height: 32px;
+        image-rendering: pixelated;
+        pointer-events: none;
+        transform-origin: top left;
+    }
     #ui { margin-top:5px; font-family:'PixelOperator', sans-serif; color:#fff; }
 </style>
 </head>

--- a/main.js
+++ b/main.js
@@ -319,6 +319,20 @@ ipcMain.on('open-start-window', () => {
     windowManager.createStartWindow();
 });
 
+ipcMain.on('open-tray-window', () => {
+    console.log('Recebido open-tray-window');
+    const win = windowManager.createTrayWindow();
+    if (currentPet && win) {
+        win.webContents.on('did-finish-load', () => {
+            win.webContents.send('pet-data', currentPet);
+        });
+    }
+    closeBattleModeWindow();
+    closeLairModeWindow();
+    closeJourneyModeWindow();
+    closeJourneySceneWindow();
+});
+
 ipcMain.on('create-pet', async (event, petData) => {
     console.log('Recebido create-pet com dados:', petData);
     try {

--- a/preload.js
+++ b/preload.js
@@ -53,7 +53,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'battle-result',
             'animation-finished', // Novo canal pra sinalizar o fim da animação
             'close-start-window',  // Fechar a janela de start
-            'open-start-window'   // Abrir a janela de start
+            'open-start-window',  // Abrir a janela de start
+            'open-tray-window'    // Abrir a janela da bandeja
         ];
         if (validChannels.includes(channel)) {
             console.log(`Enviando canal IPC: ${channel}`, data);

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -275,6 +275,18 @@ function showVictoryModal(reward) {
     };
 }
 
+function showDefeatModal() {
+    const modal = document.getElementById('defeat-modal');
+    const closeBtn = document.getElementById('defeat-close');
+    if (!modal || !closeBtn) return;
+    modal.style.display = 'flex';
+    closeBtn.onclick = () => {
+        modal.style.display = 'none';
+        window.electronAPI.send('open-tray-window');
+        closeWindow();
+    };
+}
+
 function concludeBattle(playerWon) {
     currentTurn = 'ended';
     hideMenus();
@@ -285,8 +297,7 @@ function concludeBattle(playerWon) {
         window.electronAPI.send('reward-pet', reward);
         showVictoryModal(reward);
     } else {
-        showMessage('Você perdeu!');
-        setTimeout(() => { window.electronAPI.send('open-journey-mode-window'); closeWindow(); }, 2000);
+        showDefeatModal();
     }
 }
 

--- a/scripts/lair-mode.js
+++ b/scripts/lair-mode.js
@@ -1,6 +1,7 @@
 console.log('lair-mode.js carregado');
 
 const TILE_SIZE = 32;
+const SCALE = 1.2; // mesma escala aplicada ao canvas
 // Dimensões do mapa ajustadas para caber na janela ao escalar o canvas
 // Cada tile possui 32px, então 26x20 resulta em 832x640 (escala 1.2 ≈ 1000x768)
 const MAP_W = 26;
@@ -73,8 +74,8 @@ function drawMap(){
 }
 
 function drawPlayer(){
-    playerSprite.style.left = (player.x*TILE_SIZE)+'px';
-    playerSprite.style.top = (player.y*TILE_SIZE)+'px';
+    playerSprite.style.left = (player.x * TILE_SIZE * SCALE) + 'px';
+    playerSprite.style.top = (player.y * TILE_SIZE * SCALE) + 'px';
 }
 
 function updateUI(){
@@ -125,8 +126,8 @@ function handleKey(e){
 
 function handleClick(e){
     const rect = canvas.getBoundingClientRect();
-    const x=Math.floor((e.clientX-rect.left)/TILE_SIZE);
-    const y=Math.floor((e.clientY-rect.top)/TILE_SIZE);
+    const x=Math.floor((e.clientX - rect.left) / (TILE_SIZE * SCALE));
+    const y=Math.floor((e.clientY - rect.top) / (TILE_SIZE * SCALE));
     if(Math.abs(x-player.x)+Math.abs(y-player.y)===1){
         attemptMove(x-player.x,y-player.y);
     }
@@ -138,6 +139,13 @@ document.addEventListener('DOMContentLoaded',()=>{
     playerSprite=document.getElementById('player-sprite');
     bravuraText=document.getElementById('bravura-text');
     buyBtn=document.getElementById('buy-bravura');
+    canvas.style.setProperty('--lair-scale', SCALE);
+    canvas.style.transform = `scale(${SCALE})`;
+    const container=document.getElementById('lair-container');
+    container.style.width = (canvas.width * SCALE) + 'px';
+    container.style.height = (canvas.height * SCALE) + 'px';
+    if (playerSprite) playerSprite.style.transform = `scale(${SCALE})`;
+
     tileset=new Image();
     tileset.src='assets/tileset/dungeon-tileset.png';
     tileset.onload=()=>{ drawMap(); drawPlayer(); };
@@ -151,7 +159,6 @@ document.addEventListener('DOMContentLoaded',()=>{
     document.getElementById('close-lair-mode')?.addEventListener('click',()=>window.close());
     document.getElementById('back-lair-mode')?.addEventListener('click',()=>{window.electronAPI.send('open-battle-mode-window');window.close();});
 
-    const container=document.getElementById('lair-container');
     const titleBar=document.getElementById('title-bar');
     const rect=container.getBoundingClientRect();
     const totalWidth=Math.round(rect.width)+20;


### PR DESCRIPTION
## Summary
- scale lair mode elements together
- add defeat modal returning to tray
- allow renderer to request tray window

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6866ea8c9f84832ab769ba5e85122889