### PR TITLE
Add hit effect on battle hits

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -92,6 +92,16 @@
         }
         #player-pet { left: 100px; transform: scaleX(-1); }
         #enemy-pet { right: 100px; transform: scaleX(1); }
+        .hit-effect {
+            position: absolute;
+            bottom: 120px;
+            width: 150px;
+            display: none;
+            pointer-events: none;
+            z-index: 2;
+        }
+        #player-hit { left: 100px; }
+        #enemy-hit { right: 100px; }
 
         .hud-container {
             position: absolute;
@@ -299,7 +309,9 @@
         </div>
 
         <img id="player-pet" class="pet" src="" alt="pet">
+        <img id="player-hit" class="hit-effect" src="Assets/train/hit.gif" alt="hit">
         <img id="enemy-pet" class="pet" src="" alt="inimigo">
+        <img id="enemy-hit" class="hit-effect" src="Assets/train/hit.gif" alt="hit">
 
         <div id="action-menu">
             <button id="fight-btn" class="button small-button">Lutar</button>

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -217,6 +217,14 @@ function playAttackAnimation(img, idle, attack, cb) {
     }, 1000);
 }
 
+function showHitEffect(target) {
+    const id = target === 'player' ? 'player-hit' : 'enemy-hit';
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.style.display = 'block';
+    setTimeout(() => { el.style.display = 'none'; }, 300);
+}
+
 function applyStatusEffects() {
     if (playerStatusEffects.includes('poison')) {
         const dmg = Math.ceil(playerMaxHealth * (Math.random() * 0.01 + 0.01));
@@ -342,6 +350,7 @@ function performPlayerMove(move) {
         const mult = getElementMultiplier(moveElement, enemyElement);
         const dmg = Math.round(base * mult);
         enemyHealth = Math.max(0, enemyHealth - dmg);
+        showHitEffect('enemy');
         updateHealthBars();
         if (enemyHealth <= 0) {
             concludeBattle(true);
@@ -360,6 +369,7 @@ function enemyAction() {
         const mult = getElementMultiplier(enemyElement, pet.element || 'puro');
         const dmg = Math.round(base * mult);
         playerHealth = Math.max(0, playerHealth - dmg);
+        showHitEffect('player');
         updateHealthBars();
         window.electronAPI.send('update-health', playerHealth);
         if (playerHealth <= 0) {


### PR DESCRIPTION
## Summary
- show hit animation on pets in journey scene when they take damage
- include hit effect images in the battle HTML

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6868131b46b0832a8edee17f2324f8c2