### PR TITLE
Fix create-pet error handling

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -69,6 +69,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'show-battle-error',
             'show-train-error',
             'show-store-error',
+            'create-pet-error',
             'pet-created', // Novo canal pra receber a confirmação do pet criado
             'scene-data',
             'fade-out-start-music', // Sinalizar o fade-out da música de start


### PR DESCRIPTION
## Summary
- allow `create-pet-error` IPC event from renderer

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68681f84740c832a93f16fa3a079e263