### PR TITLE
Improve pet deletion handling

### DIFF
--- a/load-pet.html
+++ b/load-pet.html
@@ -451,6 +451,8 @@
                     deleteOverlay.style.display = 'none';
                     petIdToDelete = null;
                     reloadPetList();
+                }).catch(err => {
+                    alert('Erro ao deletar pet: ' + err);
                 });
             }
         });

--- a/preload.js
+++ b/preload.js
@@ -70,6 +70,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'show-train-error',
             'show-store-error',
             'create-pet-error',
+            'delete-pet-error',
             'pet-created', // Novo canal pra receber a confirmação do pet criado
             'scene-data',
             'fade-out-start-music', // Sinalizar o fade-out da música de start


### PR DESCRIPTION
## Summary
- add cleanupOrphanPets utility
- call cleanup during app startup
- handle IPC errors on pet deletion and notify renderer
- allow listening for delete-pet-error events
- alert user when pet deletion fails

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686828a8f548832aaf76d1d16f6fefde