### PR TITLE
Fix dark creature attribute weight

### DIFF
--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -65,7 +65,9 @@ function generateSpecie(attributes) {
         "Reptilóide": defense + speed,         // Favorece defesa e velocidade
         "Ave": speed + magic,                  // Favorece velocidade e magia
         "Criatura Mística": magic + life,      // Favorece magia e vida
-        "Criatura Sombria": attack + magic,    // Favorece ataque e magia (leve variação)
+        // Anteriormente a Criatura Sombria era favorecida por ataque e magia.
+        // Ajustado para usar defesa e magia conforme solicitado.
+        "Criatura Sombria": defense + magic,   // Favorece defesa e magia
         "Monstro": defense + life,             // Favorece defesa e vida
         "Fera": attack + defense               // Favorece ataque e defesa
     };


### PR DESCRIPTION
## Summary
- adjust species generation to weigh dark creatures with defense + magic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68682cb5f3cc832a9ad7a7de1d703c04