### PR TITLE
Implement dynamic species loading

### DIFF
--- a/main.js
+++ b/main.js
@@ -130,6 +130,26 @@ const specieData = {
     'Fera': { dir: 'Fera', race: 'Foxyl' }
 };
 
+function loadSpeciesData() {
+    try {
+        const monsDir = path.join(__dirname, 'Assets', 'Mons');
+        const entries = fs.readdirSync(monsDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const dir = entry.name;
+            const existing = Object.keys(specieData).find(k => specieData[k].dir === dir);
+            const name = existing || dir;
+            if (!specieData[name]) {
+                specieData[name] = { dir };
+            }
+        }
+    } catch (err) {
+        console.error('Erro ao carregar espécies:', err);
+    }
+}
+
+loadSpeciesData();
+
 function generatePetFromEgg(eggId, rarity) {
     const specie = eggSpecieMap[eggId] || 'Ave';
     const info = specieData[specie] || {};
@@ -1816,6 +1836,10 @@ ipcMain.handle('get-nests-data', async () => {
 
 ipcMain.handle('get-nest-price', async () => {
     return getNestPrice();
+});
+
+ipcMain.handle('get-species-data', async () => {
+    return specieData;
 });
 
 ipcMain.on('set-mute-state', (event, isMuted) => {

--- a/preload.js
+++ b/preload.js
@@ -146,6 +146,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
         console.log('Enviando get-nests-data');
         return ipcRenderer.invoke('get-nests-data');
     },
+    getSpeciesData: () => {
+        console.log('Enviando get-species-data');
+        return ipcRenderer.invoke('get-species-data');
+    },
     openHatchWindow: () => {
         console.log('Enviando open-hatch-window');
         ipcRenderer.send('open-hatch-window');

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -1,32 +1,28 @@
 console.log('Script do create-pet.js carregado');
 
-// Informações de pasta e raça para cada espécie
-const specieData = {
-    'Draconídeo': { dir: 'Draconideo', race: 'draak', element: 'puro' },
-    'Reptilóide': { dir: 'Reptiloide', race: 'viborom', element: 'puro' },
-    'Ave': { dir: 'Ave', race: 'pidgly' },
-    'Criatura Mística': { dir: 'CriaturaMistica' },
-    'Criatura Sombria': { dir: 'CriaturaSombria' },
-    'Monstro': { dir: 'Monstro' },
-    'Fera': { dir: 'Fera', race: 'Foxyl' }
-};
+let specieData = {};
+let specieImages = {};
+let specieBioImages = {};
 
-// Gera o caminho da imagem base para cada espécie
-const specieImages = Object.fromEntries(
-    Object.entries(specieData).map(([key, value]) => {
-        const fileName = `${value.dir.toLowerCase()}.png`;
-        const path = `${value.dir}/${fileName}`;
-        return [key, path];
-    })
-);
-
-// Imagem em alta resolução de cada espécie para exibir na seção de biografia
-const specieBioImages = Object.fromEntries(
-    Object.entries(specieData).map(([key, value]) => {
-        const fileName = `${value.dir.toLowerCase()}.png`;
-        return [key, `${value.dir}/${fileName}`];
-    })
-);
+async function loadSpeciesData() {
+    try {
+        specieData = await window.electronAPI.getSpeciesData();
+        specieImages = Object.fromEntries(
+            Object.entries(specieData).map(([key, value]) => {
+                const fileName = `${value.dir.toLowerCase()}.png`;
+                return [key, `${value.dir}/${fileName}`];
+            })
+        );
+        specieBioImages = Object.fromEntries(
+            Object.entries(specieData).map(([key, value]) => {
+                const fileName = `${value.dir.toLowerCase()}.png`;
+                return [key, `${value.dir}/${fileName}`];
+            })
+        );
+    } catch (err) {
+        console.error('Erro ao obter species data:', err);
+    }
+}
 
 // Perguntas carregadas de data/questions.json
 
@@ -57,7 +53,7 @@ function generateSpecie(attributes) {
     const { attack, defense, speed, magic, life } = attributes;
 
     // Lista de todas as espécies
-    const species = ["Draconídeo", "Reptilóide", "Ave", "Criatura Mística", "Criatura Sombria", "Monstro", "Fera"];
+    const species = Object.keys(specieData);
 
     // Calcular um "peso" baseado nos atributos pra influenciar levemente a escolha
     const weights = {
@@ -323,7 +319,8 @@ function initQuiz() {
     showQuestion();
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+    await loadSpeciesData();
     const startButton = document.getElementById('start-quiz-button');
     const introContainer = document.getElementById('intro-container');
     const quizContainer = document.getElementById('create-pet-container');


### PR DESCRIPTION
## Summary
- scan Assets/Mons at startup to populate specie list automatically
- provide `get-species-data` IPC handler
- expose `getSpeciesData` from preload
- load species data dynamically in the create pet flow
- base specie selection on the loaded data

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68683887fbb8832aad5bc8d78d473977