### PR TITLE
Centralize species data

### DIFF
--- a/main.js
+++ b/main.js
@@ -109,46 +109,16 @@ function generateRarity() {
     if (roll < 99) return 'Epico';
     return 'Lendario';
 }
-
-const eggSpecieMap = {
-    eggAve: 'Ave',
-    eggCriaturaMistica: 'Criatura Mística',
-    eggCriaturaSombria: 'Criatura Sombria',
-    eggDraconideo: 'Draconídeo',
-    eggFera: 'Fera',
-    eggMonstro: 'Monstro',
-    eggReptiloide: 'Reptilóide'
-};
-
-const specieData = {
-    'Draconídeo': { dir: 'Draconideo', race: 'draak', element: 'puro' },
-    'Reptilóide': { dir: 'Reptiloide', race: 'viborom', element: 'puro' },
-    'Ave': { dir: 'Ave', race: 'pidgly' },
-    'Criatura Mística': { dir: 'CriaturaMistica' },
-    'Criatura Sombria': { dir: 'CriaturaSombria' },
-    'Monstro': { dir: 'Monstro' },
-    'Fera': { dir: 'Fera', race: 'Foxyl' }
-};
-
-function loadSpeciesData() {
-    try {
-        const monsDir = path.join(__dirname, 'Assets', 'Mons');
-        const entries = fs.readdirSync(monsDir, { withFileTypes: true });
-        for (const entry of entries) {
-            if (!entry.isDirectory()) continue;
-            const dir = entry.name;
-            const existing = Object.keys(specieData).find(k => specieData[k].dir === dir);
-            const name = existing || dir;
-            if (!specieData[name]) {
-                specieData[name] = { dir };
-            }
-        }
-    } catch (err) {
-        console.error('Erro ao carregar espécies:', err);
-    }
-}
-
-loadSpeciesData();
+let eggSpecieMap = {};
+let specieData = {};
+let loadSpeciesData;
+(async () => {
+    const constants = await import('./scripts/constants.js');
+    eggSpecieMap = constants.eggSpecieMap;
+    specieData = constants.specieData;
+    loadSpeciesData = constants.loadSpeciesData;
+    await loadSpeciesData(__dirname);
+})();
 
 function generatePetFromEgg(eggId, rarity) {
     const specie = eggSpecieMap[eggId] || 'Ave';
@@ -1847,10 +1817,6 @@ ipcMain.handle('get-nests-data', async () => {
 
 ipcMain.handle('get-nest-price', async () => {
     return getNestPrice();
-});
-
-ipcMain.handle('get-species-data', async () => {
-    return specieData;
 });
 
 ipcMain.on('set-mute-state', (event, isMuted) => {

--- a/preload.js
+++ b/preload.js
@@ -146,10 +146,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
         console.log('Enviando get-nests-data');
         return ipcRenderer.invoke('get-nests-data');
     },
-    getSpeciesData: () => {
-        console.log('Enviando get-species-data');
-        return ipcRenderer.invoke('get-species-data');
-    },
     openHatchWindow: () => {
         console.log('Enviando open-hatch-window');
         ipcRenderer.send('open-hatch-window');

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -39,3 +39,47 @@ export const specieBioImages = {
     'Monstro': 'Monstro/monstro.png',
     'Fera': 'Fera/fera.png'
 };
+
+export const specieData = {
+    'Draconídeo': { dir: 'Draconideo', race: 'draak', element: 'puro' },
+    'Reptilóide': { dir: 'Reptiloide', race: 'viborom', element: 'puro' },
+    'Ave': { dir: 'Ave', race: 'pidgly' },
+    'Criatura Mística': { dir: 'CriaturaMistica' },
+    'Criatura Sombria': { dir: 'CriaturaSombria' },
+    'Monstro': { dir: 'Monstro' },
+    'Fera': { dir: 'Fera', race: 'Foxyl' }
+};
+
+export const eggSpecieMap = {
+    eggAve: 'Ave',
+    eggCriaturaMistica: 'Criatura Mística',
+    eggCriaturaSombria: 'Criatura Sombria',
+    eggDraconideo: 'Draconídeo',
+    eggFera: 'Fera',
+    eggMonstro: 'Monstro',
+    eggReptiloide: 'Reptilóide'
+};
+
+let specieLoaded = false;
+
+export async function loadSpeciesData(baseDir = '.') {
+    if (specieLoaded) return;
+    specieLoaded = true;
+    try {
+        const fs = await import('fs');
+        const path = await import('path');
+        const monsDir = path.join(baseDir, 'Assets', 'Mons');
+        const entries = fs.readdirSync(monsDir, { withFileTypes: true });
+        for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const dir = entry.name;
+            const existing = Object.keys(specieData).find(k => specieData[k].dir === dir);
+            const name = existing || dir;
+            if (!specieData[name]) {
+                specieData[name] = { dir };
+            }
+        }
+    } catch (err) {
+        console.error('Erro ao carregar espécies:', err);
+    }
+}

--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -9,7 +9,9 @@ let specieBioImages = {};
 
 async function loadSpeciesData() {
     try {
-        specieData = await window.electronAPI.getSpeciesData();
+        const constants = await import('./constants.js');
+        specieData = constants.specieData;
+        specieBioImages = constants.specieBioImages;
         specieImages = Object.fromEntries(
             Object.entries(specieData).map(([key, value]) => {
                 const baseName = `${value.dir.toLowerCase()}`;
@@ -18,12 +20,6 @@ async function loadSpeciesData() {
                     ? path.join(value.dir, `${baseName}.gif`)
                     : path.join(value.dir, `${baseName}.png`);
                 return [key, img.replace(/\\/g, '/')];
-            })
-        );
-        specieBioImages = Object.fromEntries(
-            Object.entries(specieData).map(([key, value]) => {
-                const fileName = `${value.dir.toLowerCase()}.png`;
-                return [key, `${value.dir}/${fileName}`];
             })
         );
     } catch (err) {


### PR DESCRIPTION
## Summary
- centralize specie constants in `scripts/constants.js`
- load species in `main.js` using dynamic import
- update `scripts/create-pet.js` to import species data
- remove unused IPC channel and exposure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68683a91a124832abfbe4ec7fe1167c7