### PR TITLE
Add Mocha tests for loadSpeciesData

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "electron": "^35.0.1"
+    "electron": "^35.0.1",
+    "mocha": "^10.2.0"
   },
   "dependencies": {
     "electron-store": "^8.1.0"

--- a/test/loadSpeciesData.test.js
+++ b/test/loadSpeciesData.test.js
@@ -1,0 +1,10 @@
+const assert = require('assert');
+const path = require('path');
+
+describe('loadSpeciesData', function () {
+  it('returns known species when directories exist', async function () {
+    const constants = await import('../scripts/constants.js');
+    await constants.loadSpeciesData(path.resolve(__dirname, '..'));
+    assert.ok(constants.specieData.Besta, 'Expected Besta species to be loaded');
+  });
+});


### PR DESCRIPTION
## Summary
- swap placeholder test script for mocha
- add mocha as a dev dependency
- write a mocha test verifying `loadSpeciesData` picks up species from existing directories

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683c1f31f4832a9b328e656e8c353c