### PR TITLE
Add pet sprite flipping in pen

### DIFF
--- a/pen.html
+++ b/pen.html
@@ -33,6 +33,9 @@
             height: 32px;
             image-rendering: pixelated;
         }
+        .pet-sprite.flipped {
+            transform: scaleX(-1);
+        }
         .pen-container {
             position: relative;
             width: fit-content;

--- a/scripts/pen.js
+++ b/scripts/pen.js
@@ -80,9 +80,14 @@ function updateSprites(dt) {
         if (!sp.moving) {
             const col = Math.floor(Math.random() * dims.w);
             const row = Math.floor(Math.random() * dims.h);
-            sp.targetX = (col + 1) * 32;
-            sp.targetY = (row + 1) * 32;
+            const newX = (col + 1) * 32;
+            const newY = (row + 1) * 32;
+            sp.targetX = newX;
+            sp.targetY = newY;
             sp.moving = true;
+            if (sp.img) {
+                sp.img.classList.toggle('flipped', newX > sp.x);
+            }
         }
 
         const dx = sp.targetX - sp.x;


### PR DESCRIPTION
## Summary
- flip pet sprite when it walks to the right in the pen

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686872854460832a8a3601b6dc0ee6f5