### PR TITLE
Fix preload fs error

### DIFF
--- a/main.js
+++ b/main.js
@@ -111,11 +111,15 @@ function generateRarity() {
 }
 let eggSpecieMap = {};
 let specieData = {};
+let specieImages = {};
+let specieBioImages = {};
 let loadSpeciesData;
 (async () => {
     const constants = await import('./scripts/constants.js');
     eggSpecieMap = constants.eggSpecieMap;
     specieData = constants.specieData;
+    specieImages = constants.specieImages;
+    specieBioImages = constants.specieBioImages;
     loadSpeciesData = constants.loadSpeciesData;
     await loadSpeciesData(__dirname);
 })();
@@ -1817,6 +1821,11 @@ ipcMain.handle('get-nests-data', async () => {
 
 ipcMain.handle('get-nest-price', async () => {
     return getNestPrice();
+});
+
+ipcMain.handle('get-species-info', async () => {
+    await loadSpeciesData(__dirname);
+    return { specieData, specieBioImages, specieImages };
 });
 
 ipcMain.on('set-mute-state', (event, isMuted) => {

--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -40,6 +40,11 @@ export const specieBioImages = {
     'Fera': 'Fera/fera.png'
 };
 
+// Caminho da imagem de destaque de cada espécie para ser exibida na seleção
+// de pets. É preenchido pela função loadSpeciesData usando o sistema de
+// arquivos do processo principal.
+export let specieImages = {};
+
 export const specieData = {
     'Draconídeo': { dir: 'Draconideo', race: 'draak', element: 'puro' },
     'Reptilóide': { dir: 'Reptiloide', race: 'viborom', element: 'puro' },
@@ -78,6 +83,12 @@ export async function loadSpeciesData(baseDir = '.') {
             if (!specieData[name]) {
                 specieData[name] = { dir };
             }
+            const baseName = dir.toLowerCase();
+            const gifPath = path.join(monsDir, dir, `${baseName}.gif`);
+            const img = fs.existsSync(gifPath)
+                ? path.posix.join(dir, `${baseName}.gif`)
+                : path.posix.join(dir, `${baseName}.png`);
+            specieImages[name] = img.replace(/\\/g, '/');
         }
     } catch (err) {
         console.error('Erro ao carregar espécies:', err);


### PR DESCRIPTION
## Summary
- remove direct `fs` usage in preload script
- compute specie images in constants
- expose species info via IPC from main process

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aeeecc03c832aa1da07930d714455