### PR TITLE
Fix burn icon path

### DIFF
--- a/data/status-effects.json
+++ b/data/status-effects.json
@@ -2,7 +2,7 @@
   {
     "id": "burn",
     "name": "Queimadura",
-    "icon": "Assets/Icons/burning.png",
+    "icon": "Assets/Icons/burn.png",
     "duration": "2-3",
     "damage": "-2% a -3% da vida total por turno",
     "extra": "Pode impedir regeneração durante o efeito"

--- a/scripts/train.js
+++ b/scripts/train.js
@@ -2,7 +2,7 @@ import { rarityGradients } from './constants.js';
 import { calculateMovePower } from './moveEffectiveness.js';
 
 const statusIcons = {
-    'queimado': 'Assets/Icons/burning.png',
+    'queimado': 'Assets/Icons/burn.png',
     'envenenamento': 'Assets/Icons/poison.png',
     'sangramento': 'Assets/Icons/bleed.png',
     'dormencia': 'Assets/Icons/sleep.png',


### PR DESCRIPTION
## Summary
- fix burn icon path for train script
- update burn icon path for JSON status effects

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af17af490832aa2412276f32fafd3