### PR TITLE
fix: ensure solid walls around dungeon

### DIFF
--- a/scripts/lair-mode.js
+++ b/scripts/lair-mode.js
@@ -112,15 +112,15 @@ function addRandomLoops(){
     }
 }
 
-// Remove the extra interior walls generated along the last column/row
-// before applying orientation so the map doesn't end up with doubled
-// borders.
+// Close any openings created along the edges so side corridors never end up
+// two tiles wide. This keeps the dungeon surrounded by a single layer of
+// walls.
 function trimExtraWalls(){
     for(let x=0;x<MAP_W;x++){
-        if(map[MAP_H-2][x]==='WALL') map[MAP_H-2][x]='FLOOR';
+        if(map[MAP_H-2][x]==='FLOOR') map[MAP_H-2][x]='WALL';
     }
     for(let y=0;y<MAP_H;y++){
-        if(map[y][MAP_W-2]==='WALL') map[y][MAP_W-2]='FLOOR';
+        if(map[y][MAP_W-2]==='FLOOR') map[y][MAP_W-2]='WALL';
     }
 }
 


### PR DESCRIPTION
## Summary
- keep outer walls solid so corridors don't become two tiles wide

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b22186524832abbf26306343d6af1