### PR TITLE
Add new pet species

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -52,7 +52,11 @@ export const specieData = {
     'Criatura Mística': { dir: 'CriaturaMistica' },
     'Criatura Sombria': { dir: 'CriaturaSombria' },
     'Monstro': { dir: 'Monstro' },
-    'Fera': { dir: 'Fera', race: 'Foxyl' }
+    'Fera': { dir: 'Fera', race: 'Foxyl' },
+    'Pidgly': { dir: 'Ave', race: 'Pidgly', element: 'terra' },
+    'Ashfang': { dir: 'Fera', race: 'Ashfang', element: 'fogo' },
+    'Ignis': { dir: 'Ave', race: 'ignis', element: 'fogo' },
+    'Mawthorn': { dir: 'Monstro', race: 'Mawthorn', element: 'agua' }
 };
 
 export const eggSpecieMap = {


### PR DESCRIPTION
## Summary
- register new pet species in specieData only
- avoid adding extra fallbacks for new races

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c42d91c98832aa681a737755dd437