### PR TITLE
Add element-aware species generation

### DIFF
--- a/scripts/create-pet.js
+++ b/scripts/create-pet.js
@@ -40,11 +40,15 @@ function generateRarity() {
 }
 
 // Função ajustada para definir a espécie de forma mais aleatória
-function generateSpecie(attributes) {
+function generateSpecie(attributes, element) {
     const { attack, defense, speed, magic, life } = attributes;
 
-    // Lista de todas as espécies
-    const species = Object.keys(specieData);
+    // Filtra as espécies pelo elemento selecionado
+    let species = Object.keys(specieData).filter(s => specieData[s].element === element);
+    if (species.length === 0) {
+        // Caso nenhuma espécie possua o elemento, usar apenas as sem elemento definido
+        species = Object.keys(specieData).filter(s => !specieData[s].element);
+    }
 
     // Calcular um "peso" baseado nos atributos pra influenciar levemente a escolha
     const weights = {
@@ -236,7 +240,7 @@ function showNameSelection(element) {
         stats.life *= 10;
 
         // Gerar espécie e raridade
-        const specie = generateSpecie(stats);
+        const specie = generateSpecie(stats, element);
         const rarity = generateRarity();
 
         // Definir a imagem e demais caminhos de acordo com a espécie
@@ -322,3 +326,11 @@ document.addEventListener('DOMContentLoaded', async () => {
         loadQuestions();
     });
 });
+
+// Permite utilizar a função em testes Node.js
+if (typeof module !== 'undefined') {
+    module.exports = {
+        generateSpecie,
+        _setSpecieData: data => { specieData = data; }
+    };
+}

--- a/test/generateSpecie.test.js
+++ b/test/generateSpecie.test.js
@@ -1,0 +1,31 @@
+const assert = require('assert');
+const path = require('path');
+
+describe('generateSpecie', function () {
+  function loadCreatePet() {
+    delete require.cache[require.resolve('../scripts/create-pet.js')];
+    global.document = { addEventListener: () => {} };
+    global.window = {};
+    return require('../scripts/create-pet.js');
+  }
+
+  it('prefers element specific species when available', function () {
+    const createPet = loadCreatePet();
+    createPet._setSpecieData({
+      'Mawthorn': { element: 'agua' },
+      'Monstro': {}
+    });
+    const specie = createPet.generateSpecie({ attack: 1, defense: 1, speed: 1, magic: 1, life: 1 }, 'agua');
+    assert.strictEqual(specie, 'Mawthorn');
+  });
+
+  it('falls back to generic species when none match element', function () {
+    const createPet = loadCreatePet();
+    createPet._setSpecieData({
+      'Monstro': {},
+      'Fera': {}
+    });
+    const specie = createPet.generateSpecie({ attack: 1, defense: 1, speed: 1, magic: 1, life: 1 }, 'terra');
+    assert.ok(['Monstro', 'Fera'].includes(specie));
+  });
+});


### PR DESCRIPTION
## Summary
- filter species by selected element when generating pets
- fall back to generic species if none have the element
- pass the chosen element when generating species
- expose a helper for tests and add unit tests for `generateSpecie`

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c4e7706b8832ab6d3a8a274988b20