### PR TITLE
Ensure load-pet uses PNG fallback

### DIFF
--- a/scripts/petManager.js
+++ b/scripts/petManager.js
@@ -50,16 +50,14 @@ function ensureStatusImage(pet) {
     const relativeDir = basePath ? path.posix.dirname(basePath) : null;
 
     if (relativeDir && relativeDir !== '.') {
-        if (!pet.statusImage) {
-            const baseDir = path.join(__dirname, '..', 'Assets', 'Mons', relativeDir);
-            const gifPath = path.join(baseDir, 'front.gif');
-            const pngPath = path.join(baseDir, 'front.png');
+        const baseDir = path.join(__dirname, '..', 'Assets', 'Mons', relativeDir);
+        const gifPath = path.join(baseDir, 'front.gif');
+        const pngPath = path.join(baseDir, 'front.png');
 
-            if (fsSync.existsSync(gifPath)) {
-                pet.statusImage = path.posix.join(relativeDir, 'front.gif');
-            } else if (fsSync.existsSync(pngPath)) {
-                pet.statusImage = path.posix.join(relativeDir, 'front.png');
-            }
+        if (fsSync.existsSync(gifPath)) {
+            pet.statusImage = path.posix.join(relativeDir, 'front.gif');
+        } else if (fsSync.existsSync(pngPath)) {
+            pet.statusImage = path.posix.join(relativeDir, 'front.png');
         }
     }
 


### PR DESCRIPTION
## Summary
- always verify front.gif and front.png when building pet status images

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c50921458832aad9fc47245f9953a