### PR TITLE
Fix tray closing on last pet deletion

### DIFF
--- a/main.js
+++ b/main.js
@@ -454,6 +454,14 @@ ipcMain.handle('delete-pet', async (event, petId) => {
         const result = await petManager.deletePet(petId);
         console.log('Pet excluído:', result);
         broadcastPenUpdate();
+
+        // Verificar se ainda existem pets após a exclusão
+        const remaining = await petManager.listPets();
+        if (remaining.length === 0) {
+            currentPet = null;
+            windowManager.closeTrayWindow();
+        }
+
         return result;
     } catch (err) {
         console.error('Erro ao deletar pet:', err);


### PR DESCRIPTION
## Summary
- close tray window in main process when deleting the last pet

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c5a86690c832abf5a7620798463f2