### PR TITLE
Update journey progress handling

### DIFF
--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -27,6 +27,10 @@ async function computeAttackSrc(idleRelative) {
 }
 
 let pet = null;
+
+function getJourneyKey(base) {
+    return pet && pet.petId ? `${base}_${pet.petId}` : base;
+}
 let itemsInfo = {};
 let statusEffectsInfo = {};
 let playerStatusEffects = [];
@@ -299,7 +303,7 @@ function concludeBattle(playerWon) {
     currentTurn = 'ended';
     hideMenus();
     window.electronAPI.send('battle-result', { win: playerWon });
-    localStorage.setItem('journeyBattleWin', playerWon ? '1' : '0');
+    localStorage.setItem(getJourneyKey('journeyBattleWin'), playerWon ? '1' : '0');
     if (playerWon) {
         const reward = generateReward();
         window.electronAPI.send('reward-pet', reward);


### PR DESCRIPTION
## Summary
- compute journey keys per pet
- handle dynamic keys when advancing or completing the journey
- track battle results per pet

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c61c54f34832aaf5026e44673ecbb