### PR TITLE
Implement global difficulty settings

### DIFF
--- a/main.js
+++ b/main.js
@@ -63,6 +63,14 @@ function setItems(value) {
     store.set('items', value);
 }
 
+function getDifficulty() {
+    return store.get('difficulty', 1);
+}
+
+function setDifficulty(value) {
+    store.set('difficulty', value);
+}
+
 const penLimits = { small: 3, medium: 6, large: 10 };
 
 function getPenInfo() {
@@ -1829,6 +1837,14 @@ ipcMain.handle('get-nests-data', async () => {
 
 ipcMain.handle('get-nest-price', async () => {
     return getNestPrice();
+});
+
+ipcMain.handle('get-difficulty', async () => {
+    return getDifficulty();
+});
+
+ipcMain.on('set-difficulty', (event, value) => {
+    setDifficulty(value);
 });
 
 ipcMain.handle('get-species-info', async () => {

--- a/preload.js
+++ b/preload.js
@@ -42,6 +42,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
             'resize-pen-window',
             'resize-lair-window',
             'set-mute-state',
+            'set-difficulty',
             'get-journey-images',
             'reward-pet',
             'journey-complete',
@@ -153,6 +154,14 @@ contextBridge.exposeInMainWorld('electronAPI', {
     getNestsData: () => {
         console.log('Enviando get-nests-data');
         return ipcRenderer.invoke('get-nests-data');
+    },
+    getDifficulty: () => {
+        console.log('Enviando get-difficulty');
+        return ipcRenderer.invoke('get-difficulty');
+    },
+    setDifficulty: (value) => {
+        console.log('Enviando set-difficulty', value);
+        ipcRenderer.send('set-difficulty', value);
     },
     openHatchWindow: () => {
         console.log('Enviando open-hatch-window');

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -45,6 +45,17 @@ let enemyIdleSrc = '';
 let enemyAttackSrc = '';
 let enemyElement = 'puro';
 const enemyAttackCost = 10;
+let difficulty = 1;
+
+if (window.electronAPI?.getDifficulty) {
+    window.electronAPI.getDifficulty().then(val => {
+        difficulty = typeof val === 'number' ? val : 1;
+        if (difficulty === 1 && window.electronAPI?.setDifficulty) {
+            difficulty = 0.8;
+            window.electronAPI.setDifficulty(difficulty);
+        }
+    }).catch(() => { difficulty = 1; });
+}
 
 async function loadItemsInfo() {
     try {
@@ -371,7 +382,7 @@ function enemyAction() {
         updateHealthBars();
         const base = 8;
         const mult = getElementMultiplier(enemyElement, pet.element || 'puro');
-        const dmg = Math.round(base * mult);
+        const dmg = Math.round(base * mult * difficulty);
         playerHealth = Math.max(0, playerHealth - dmg);
         showHitEffect('player');
         updateHealthBars();

--- a/scripts/lair-mode.js
+++ b/scripts/lair-mode.js
@@ -52,6 +52,13 @@ let level = 1;
 let exitPos = null;
 let playerHealth = 0;
 let playerMaxHealth = 0;
+let difficulty = 1;
+
+if (window.electronAPI?.getDifficulty) {
+    window.electronAPI.getDifficulty().then(val => {
+        difficulty = typeof val === 'number' ? val : 1;
+    }).catch(() => { difficulty = 1; });
+}
 
 const CONSUMABLES = ['healthPotion','meat','staminaPotion','chocolate'];
 const ACCESSORIES = ['finger','turtleShell','feather','orbe'];
@@ -236,7 +243,7 @@ function updateUI(){
 
 function applyDamage(amount){
     if(!playerMaxHealth) return;
-    const dmg = Math.max(0, amount||0);
+    const dmg = Math.max(0, Math.round((amount||0) * difficulty));
     if(dmg<=0) return;
     playerHealth = Math.max(0, playerHealth - dmg);
     window.electronAPI.send('update-health', playerHealth);


### PR DESCRIPTION
## Summary
- add helpers in `main.js` to persist difficulty via `electron-store`
- expose `getDifficulty` and `setDifficulty` IPC methods in `preload.js`
- fetch global difficulty in journey scenes and lair mode
- scale enemy damage by difficulty and persist lowered difficulty for journeys

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c63919078832a8cb8d822501d8ed3