### PR TITLE
Add fallback from GIF to PNG in journey scene

### DIFF
--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -22,8 +22,15 @@ function imageExists(src) {
 
 async function computeAttackSrc(idleRelative) {
     if (!idleRelative) return '';
-    const candidate = assetPath(idleRelative.replace(/idle\.gif$/i, 'attack.gif'));
+    const candidate = assetPath(idleRelative.replace(/idle\.(gif|png)$/i, 'attack.gif'));
     return (await imageExists(candidate)) ? candidate : assetPath(idleRelative);
+}
+
+async function computeFrontSrc(idleRelative) {
+    if (!idleRelative) return '';
+    const gif = assetPath(idleRelative.replace(/idle\.(gif|png)$/i, 'front.gif'));
+    if (await imageExists(gif)) return gif;
+    return assetPath(idleRelative.replace(/idle\.(gif|png)$/i, 'front.png'));
 }
 
 let pet = null;
@@ -470,13 +477,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         if (data.playerPet && playerFront) {
-            const frontPath = data.playerPet.replace(/idle\.gif$/i, 'front.gif');
-            playerFront.src = assetPath(frontPath);
+            playerFront.src = await computeFrontSrc(data.playerPet);
         }
 
         if (data.enemyPet && enemyFront) {
-            const frontPath = data.enemyPet.replace(/idle\.gif$/i, 'front.gif');
-            enemyFront.src = assetPath(frontPath);
+            enemyFront.src = await computeFrontSrc(data.enemyPet);
         }
 
         if (data.enemyElement) {


### PR DESCRIPTION
## Summary
- add `computeFrontSrc` to support front PNG fallback
- enhance `computeAttackSrc` to handle `.png` idle sources
- use the new helper when loading player and enemy front images

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dbbf4b75c832a86700d5977abf899