### PR TITLE
Adjust difficulty IPC handling

### DIFF
--- a/main.js
+++ b/main.js
@@ -1843,8 +1843,9 @@ ipcMain.handle('get-difficulty', async () => {
     return getDifficulty();
 });
 
-ipcMain.on('set-difficulty', (event, value) => {
+ipcMain.handle('set-difficulty', async (event, value) => {
     setDifficulty(value);
+    return true;
 });
 
 ipcMain.handle('get-species-info', async () => {

--- a/preload.js
+++ b/preload.js
@@ -161,7 +161,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     setDifficulty: (value) => {
         console.log('Enviando set-difficulty', value);
-        ipcRenderer.send('set-difficulty', value);
+        return ipcRenderer.invoke('set-difficulty', value);
     },
     openHatchWindow: () => {
         console.log('Enviando open-hatch-window');
@@ -173,5 +173,4 @@ contextBridge.exposeInMainWorld('electronAPI', {
     },
     getSpeciesInfo
 });
-
 console.log('electronAPI exposto com sucesso');

--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -66,10 +66,18 @@ document.addEventListener('DOMContentLoaded', () => {
         eventModal.style.display = 'flex';
     }
 
-    function handleRandomEvent(img) {
+    async function handleRandomEvent(img) {
         const roll = Math.random() * 100;
         if (roll < 70) {
             localStorage.setItem(getJourneyKey('journeyPendingAdvance'), '1');
+            const diff = 1;
+            if (window.electronAPI?.setDifficulty) {
+                try {
+                    await window.electronAPI.setDifficulty(diff);
+                } catch (err) {
+                    console.error('Erro ao definir dificuldade:', err);
+                }
+            }
             window.electronAPI?.send('open-journey-scene-window', { background: img });
             return true;
         } else if (roll < 85) {
@@ -173,7 +181,15 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function handleBossFight(img) {
+    async function handleBossFight(img) {
+        const diff = 1;
+        if (window.electronAPI?.setDifficulty) {
+            try {
+                await window.electronAPI.setDifficulty(diff);
+            } catch (err) {
+                console.error('Erro ao definir dificuldade:', err);
+            }
+        }
         window.electronAPI?.send('open-journey-scene-window', { background: img });
     }
 
@@ -204,16 +220,16 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
 
-        point.addEventListener('click', () => {
+        point.addEventListener('click', async () => {
             if (idx !== currentIndex) return;
             if (point.classList.contains('path-point')) {
                 const img = point.dataset.image;
                 if (img) {
                     localStorage.setItem(getJourneyKey('journeyPendingAdvance'), '1');
-                    handleBossFight(img);
+                    await handleBossFight(img);
                 }
             } else {
-                const startedBattle = handleRandomEvent(nextBackground);
+                const startedBattle = await handleRandomEvent(nextBackground);
                 if (!startedBattle) {
                     advancePoint();
                 }

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -55,11 +55,15 @@ const enemyAttackCost = 10;
 let difficulty = 1;
 
 if (window.electronAPI?.getDifficulty) {
-    window.electronAPI.getDifficulty().then(val => {
+    window.electronAPI.getDifficulty().then(async val => {
         difficulty = typeof val === 'number' ? val : 1;
         if (difficulty === 1 && window.electronAPI?.setDifficulty) {
             difficulty = 0.8;
-            window.electronAPI.setDifficulty(difficulty);
+            try {
+                await window.electronAPI.setDifficulty(difficulty);
+            } catch (err) {
+                console.error('Erro ao definir dificuldade:', err);
+            }
         }
     }).catch(() => { difficulty = 1; });
 }


### PR DESCRIPTION
## Summary
- make `setDifficulty` IPC call asynchronous
- add new `ipcMain.handle('set-difficulty')` in main process
- await difficulty setting before opening new journey scenes
- propagate awaiting difficulty changes in journey scene startup

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dc50792e4832a92bb71222cf00ede