### PR TITLE
Improve journey difficulty scaling

### DIFF
--- a/scripts/journey-map.js
+++ b/scripts/journey-map.js
@@ -66,10 +66,18 @@ document.addEventListener('DOMContentLoaded', () => {
         eventModal.style.display = 'flex';
     }
 
-    function handleRandomEvent(img) {
+    function computeDifficulty(index) {
+        const base = 0.8;
+        const step = 0.03;
+        return base + index * step;
+    }
+
+    function handleRandomEvent(img, index) {
         const roll = Math.random() * 100;
         if (roll < 70) {
             localStorage.setItem(getJourneyKey('journeyPendingAdvance'), '1');
+            const diff = computeDifficulty(index);
+            window.electronAPI?.setDifficulty(diff);
             window.electronAPI?.send('open-journey-scene-window', { background: img });
             return true;
         } else if (roll < 85) {
@@ -173,7 +181,9 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    function handleBossFight(img) {
+    function handleBossFight(img, index) {
+        const diff = computeDifficulty(index);
+        window.electronAPI?.setDifficulty(diff);
         window.electronAPI?.send('open-journey-scene-window', { background: img });
     }
 
@@ -210,10 +220,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 const img = point.dataset.image;
                 if (img) {
                     localStorage.setItem(getJourneyKey('journeyPendingAdvance'), '1');
-                    handleBossFight(img);
+                    handleBossFight(img, idx);
                 }
             } else {
-                const startedBattle = handleRandomEvent(nextBackground);
+                const startedBattle = handleRandomEvent(nextBackground, idx);
                 if (!startedBattle) {
                     advancePoint();
                 }

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -45,6 +45,7 @@ let playerHealth = 100;
 let playerMaxHealth = 100;
 let enemyHealth = 100;
 let enemyEnergy = 100;
+let enemyAttributes = { attack: 5, defense: 5, magic: 5, speed: 5 };
 let currentTurn = 'player';
 let playerIdleSrc = '';
 let playerAttackSrc = '';
@@ -247,6 +248,23 @@ function showHitEffect(target) {
     setTimeout(() => { el.style.display = 'none'; }, 300);
 }
 
+function initializeBattle() {
+    if (!pet) return;
+    const lvl = pet.level || 1;
+    enemyAttributes = {
+        attack: lvl * 2,
+        defense: lvl,
+        magic: lvl * 2,
+        speed: lvl * 1.5,
+    };
+    if ((pet.attributes?.speed || 0) < enemyAttributes.speed) {
+        currentTurn = 'enemy';
+        setTimeout(enemyAction, 800);
+    } else {
+        currentTurn = 'player';
+    }
+}
+
 function applyStatusEffects() {
     if (playerStatusEffects.includes('poison')) {
         const dmg = Math.ceil(playerMaxHealth * (Math.random() * 0.01 + 0.01));
@@ -370,7 +388,21 @@ function performPlayerMove(move) {
             ? (move.elements.includes(pet.element) ? pet.element : move.elements[0])
             : (move.element || pet.element || 'puro');
         const mult = getElementMultiplier(moveElement, enemyElement);
-        const dmg = Math.round(base * mult);
+
+        const accuracy = typeof move.accuracy === 'number' ? move.accuracy : 1;
+        const speedDiff = (enemyAttributes.speed || 0) - (pet.attributes?.speed || 0);
+        const dodge = Math.max(0, Math.min(0.3, speedDiff / 100));
+        if (Math.random() > accuracy * (1 - dodge)) {
+            showMessage('Ataque errou!');
+            endPlayerTurn();
+            return;
+        }
+
+        const isSpecial = (move.type || 'physical') === 'special';
+        const atkStat = isSpecial ? (pet.attributes?.magic || 0) : (pet.attributes?.attack || 0);
+        const defStat = enemyAttributes.defense || 0;
+        const scaled = (base + atkStat * 0.5) * mult * (100 / (100 + defStat));
+        const dmg = Math.max(1, Math.round(scaled));
         enemyHealth = Math.max(0, enemyHealth - dmg);
         showHitEffect('enemy');
         updateHealthBars();
@@ -387,9 +419,22 @@ function enemyAction() {
     playAttackAnimation(enemyImg, enemyIdleSrc, enemyAttackSrc, () => {
         enemyEnergy = Math.max(0, enemyEnergy - enemyAttackCost);
         updateHealthBars();
-        const base = 8;
+
+        const accuracy = 0.9;
+        const speedDiff = (pet.attributes?.speed || 0) - (enemyAttributes.speed || 0);
+        const dodge = Math.max(0, Math.min(0.3, speedDiff / 100));
+        if (Math.random() > accuracy * (1 - dodge)) {
+            showMessage('Inimigo errou!');
+            currentTurn = 'player';
+            applyStatusEffects();
+            return;
+        }
+
+        const base = 8 + enemyAttributes.attack;
         const mult = getElementMultiplier(enemyElement, pet.element || 'puro');
-        const dmg = Math.round(base * mult * difficulty);
+        const defStat = pet.attributes?.defense || 0;
+        const scaled = base * mult * difficulty * (100 / (100 + defStat));
+        const dmg = Math.max(1, Math.round(scaled));
         playerHealth = Math.max(0, playerHealth - dmg);
         showHitEffect('player');
         updateHealthBars();
@@ -529,5 +574,6 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         updateMoves();
         updateItems();
+        initializeBattle();
     });
 });


### PR DESCRIPTION
## Summary
- tune difficulty in journey mode based on the current path index
- set difficulty before opening battle scenes

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dbc927058832abcf12ffb6d90b90b