### PR TITLE
Add new pet species data

### DIFF
--- a/scripts/constants.js
+++ b/scripts/constants.js
@@ -56,7 +56,11 @@ export const specieData = {
     'Pidgly': { dir: 'Ave', race: 'Pidgly', element: 'terra' },
     'Ashfang': { dir: 'Fera', race: 'Ashfang', element: 'fogo' },
     'Ignis': { dir: 'Ave', race: 'ignis', element: 'fogo' },
-    'Mawthorn': { dir: 'Monstro', race: 'Mawthorn', element: 'agua' }
+    'Mawthorn': { dir: 'Monstro', race: 'Mawthorn', element: 'agua' },
+    'Leoracal': { dir: 'Fera', race: 'Kael', element: 'terra' },
+    'Owlberoth': { dir: 'CriaturaMistica', race: 'Owlberoth', element: 'terra' },
+    'Digitama': { dir: 'CriaturaMistica', race: 'Digitama', element: 'fogo' },
+    'Kael': { dir: 'Fera', race: 'Kael', element: 'agua' }
 };
 
 export const eggSpecieMap = {

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -2,7 +2,15 @@ import { rarityGradients, rarityColors, specieBioImages, specieDirs } from './co
 
 const raceNames = {
     viborom: 'Viborom',
-    draak: 'Draak Olhos de Esmeralda'
+    draak: 'Draak Olhos de Esmeralda',
+    Pidgly: 'Pidgly',
+    Ashfang: 'Ashfang',
+    ignis: 'Ignis',
+    Mawthorn: 'Mawthorn',
+    Leoracal: 'Leoracal',
+    Owlberoth: 'Owlberoth',
+    Digitama: 'Digitama',
+    Kael: 'Kael'
 };
 
 function getRequiredXpForNextLevel(level) {


### PR DESCRIPTION
## Summary
- append Owlberoth, Digitama, Kael and Leoracal to specie data
- create folders for new pet images
- add race name labels for the new species

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eaaaa0abc832abc919745260af9c1