### PR TITLE
Adjust Kadir Point rewards

### DIFF
--- a/main.js
+++ b/main.js
@@ -675,7 +675,7 @@ ipcMain.on('battle-pet', async () => {
         while (currentPet.experience >= requiredXp && currentPet.level < 100) {
             currentPet.level += 1;
             currentPet.experience -= requiredXp;
-            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 1;
+            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 5;
             increaseAttributesOnLevelUp(currentPet);
             console.log(`Pet subiu para o nível ${currentPet.level}! XP restante: ${currentPet.experience}`);
             requiredXp = getRequiredXpForNextLevel(currentPet.level);
@@ -1679,7 +1679,7 @@ ipcMain.on('reward-pet', async (event, reward) => {
         while (currentPet.experience >= requiredXp && currentPet.level < 100) {
             currentPet.level += 1;
             currentPet.experience -= requiredXp;
-            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 1;
+            currentPet.kadirPoints = (currentPet.kadirPoints || 0) + 5;
             currentPet.bravura = (currentPet.bravura || 0) + 1;
             increaseAttributesOnLevelUp(currentPet);
             requiredXp = getRequiredXpForNextLevel(currentPet.level);

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -299,7 +299,7 @@ function generateReward() {
         return { experience: Math.floor(Math.random() * 10) + 5 };
     }
     if (choice === 'kadirPoints') {
-        return { kadirPoints: 1 };
+        return { kadirPoints: Math.floor(Math.random() * 5) + 1 };
     }
     if (choice === 'coins') {
         return { coins: Math.floor(Math.random() * 5) + 1 };


### PR DESCRIPTION
## Summary
- award 5 Kadir Points when the pet levels up
- allow battle rewards to give between 1 and 5 Kadir Points

## Testing
- `npm test` *(fails: `mocha` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec564ded0832abb7d781790e4f9cb