### PR TITLE
Fix repeated enemy turns in journey battles

### DIFF
--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -34,6 +34,7 @@ async function computeFrontSrc(idleRelative) {
 }
 
 let pet = null;
+let battleInitialized = false;
 
 function getJourneyKey(base) {
     return pet && pet.petId ? `${base}_${pet.petId}` : base;
@@ -259,7 +260,8 @@ function showHitEffect(target) {
 }
 
 function initializeBattle() {
-    if (!pet) return;
+    if (battleInitialized || !pet) return;
+    battleInitialized = true;
     const lvl = pet.level || 1;
     enemyAttributes = {
         attack: lvl * 2,


### PR DESCRIPTION
## Summary
- avoid reinitializing battle multiple times when `pet-data` events arrive
- guard `initializeBattle` with a `battleInitialized` flag

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ece47f728832abf3af18c5ce34568