### PR TITLE
Fix healing timing in journey battles

### DIFF
--- a/main.js
+++ b/main.js
@@ -1441,7 +1441,7 @@ ipcMain.on('buy-item', async (event, item) => {
     });
 });
 
-ipcMain.on('use-item', async (event, item) => {
+ipcMain.handle('use-item', async (event, item) => {
     if (!currentPet) return;
     const items = getItems();
     if (!items[item]) return;
@@ -1498,6 +1498,7 @@ ipcMain.on('use-item', async (event, item) => {
     BrowserWindow.getAllWindows().forEach(w => {
         if (w.webContents) w.webContents.send('pet-data', currentPet);
     });
+    return currentPet.currentHealth;
 });
 
 ipcMain.on('unequip-item', async () => {

--- a/preload.js
+++ b/preload.js
@@ -171,6 +171,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
         console.log('Enviando close-hatch-window');
         ipcRenderer.send('close-hatch-window');
     },
+    useItem: (id) => ipcRenderer.invoke('use-item', id),
     getSpeciesInfo
-});
-console.log('electronAPI exposto com sucesso');
+});console.log('electronAPI exposto com sucesso');

--- a/scripts/items.js
+++ b/scripts/items.js
@@ -47,7 +47,7 @@ document.addEventListener('DOMContentLoaded', () => {
     swapCancelBtn = document.getElementById('swap-cancel');
     swapConfirmBtn?.addEventListener('click', () => {
         if (pendingEquipId) {
-            window.electronAPI.send('use-item', pendingEquipId);
+            window.electronAPI.useItem(pendingEquipId);
         }
         pendingEquipId = null;
         if (swapModal) swapModal.style.display = 'none';
@@ -147,7 +147,7 @@ function updateItems() {
                         return;
                     }
                 }
-                window.electronAPI.send('use-item', id);
+                window.electronAPI.useItem(id);
             });
         }
 

--- a/scripts/journey-scene.js
+++ b/scripts/journey-scene.js
@@ -169,11 +169,12 @@ function updateItems() {
         btn.appendChild(img);
         btn.appendChild(label);
 
-        btn.addEventListener('click', () => {
+        btn.addEventListener('click', async () => {
             if (currentTurn !== 'player' || actionInProgress) return;
             actionInProgress = true;
             hideMenus();
-            window.electronAPI.send('use-item', id);
+            const newHealth = await window.electronAPI.useItem(id);
+            if (typeof newHealth === 'number') playerHealth = newHealth;
             endPlayerTurn();
         });
 

--- a/scripts/status.js
+++ b/scripts/status.js
@@ -136,7 +136,7 @@ function openEquipModal() {
         btn.appendChild(textWrap);
 
         btn.addEventListener('click', () => {
-            window.electronAPI.send('use-item', id);
+            window.electronAPI.useItem(id);
             closeEquipModal();
         });
 


### PR DESCRIPTION
## Summary
- return updated health from main process when using items
- expose `useItem` as an async method on `electronAPI`
- wait for item healing before ending the player's turn
- update status and item screens to use the new method

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed0472940832a88ff2ea9033d4c96