### PR TITLE
Display XP rewards after victory

### DIFF
--- a/journey-scene.html
+++ b/journey-scene.html
@@ -325,6 +325,7 @@
         <div id="victory-modal" style="display:none; position:fixed; top:0; left:0; width:100%; height:100%; background:rgba(0,0,0,0.7); align-items:center; justify-content:center; z-index:1000;">
             <div style="background:#2a323e; border:2px solid #fff; padding:10px; border-radius:8px; text-align:center;">
                 <div id="victory-text" style="margin-bottom:8px;">Parabéns! Você venceu!</div>
+                <div id="victory-xp" style="margin-bottom:8px;"></div>
                 <div id="victory-reward" style="margin-bottom:8px;"></div>
                 <button id="victory-close" class="button small-button">OK</button>
             </div>


### PR DESCRIPTION
## Summary
- show XP earned in the victory modal
- grant base XP on every battle victory

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ed4dd2d14832aa15986058cf1473f